### PR TITLE
core: check if StorageClass is nil

### DIFF
--- a/core/job.go
+++ b/core/job.go
@@ -766,19 +766,24 @@ func (j *Job) Run(wp *WorkerParams) error {
 			if li.isCommonPrefix {
 				j.out(shortOk, "%19s %1s %-38s  %12s  %s", "", "", "", "DIR", li.parsedKey)
 			} else {
-				var cls, etag, size string
+				var (
+					cls        = "?"
+					etag, size string
+				)
 
-				switch *li.StorageClass {
-				case s3.ObjectStorageClassStandard:
-					cls = ""
-				case s3.ObjectStorageClassGlacier:
-					cls = "G"
-				case s3.ObjectStorageClassReducedRedundancy:
-					cls = "R"
-				case s3.TransitionStorageClassStandardIa:
-					cls = "I"
-				default:
-					cls = "?"
+				if li.StorageClass != nil {
+					switch *li.StorageClass {
+					case s3.ObjectStorageClassStandard:
+						cls = ""
+					case s3.ObjectStorageClassGlacier:
+						cls = "G"
+					case s3.ObjectStorageClassReducedRedundancy:
+						cls = "R"
+					case s3.TransitionStorageClassStandardIa:
+						cls = "I"
+					default:
+						cls = "?"
+					}
 				}
 
 				if showETags {


### PR DESCRIPTION
Not all S3 compatible services support StorageClass functionality. I.e. Google Cloud Storage, in-memory S3 services.