### PR TITLE
Correctly parse key if prefix is not a directory

### DIFF
--- a/s3url/s3url.go
+++ b/s3url/s3url.go
@@ -154,7 +154,15 @@ func parseNonBatch(prefix string, key string) string {
 	if key == prefix || !strings.HasPrefix(key, prefix) {
 		return key
 	}
-	parsedKey := strings.TrimPrefix(key, prefix)
+	parsedKey := strings.TrimSuffix(key, s3Separator)
+	if loc := strings.LastIndex(parsedKey, s3Separator); loc < len(prefix) {
+		if loc < 0 {
+			return key
+		}
+		parsedKey = key[loc:]
+		return strings.TrimPrefix(parsedKey, s3Separator)
+	}
+	parsedKey = strings.TrimPrefix(key, prefix)
 	parsedKey = strings.TrimPrefix(parsedKey, s3Separator)
 	index := strings.Index(parsedKey, s3Separator) + 1
 	if index <= 0 || index >= len(parsedKey) {

--- a/s3url/s3url_test.go
+++ b/s3url/s3url_test.go
@@ -326,6 +326,18 @@ func Test_parseNonBatch(t *testing.T) {
 			key:    "a/b/asset.txt",
 			want:   "asset.txt",
 		},
+		{
+			name:   "parse_key_and_return_current_asset_if_prefix_is_not_dir",
+			prefix: "a/b/ab",
+			key:    "a/b/abc.txt",
+			want:   "abc.txt",
+		},
+		{
+			name:   "parse_key_and_return_current_dir_if_prefix_is_not_dir",
+			prefix: "test",
+			key:    "testdir/",
+			want:   "testdir/",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
URL parse for non-batch operations is not working as expected if the prefix is not a directory. This behaviour was broken on 3e51198607e7a45566f7df1cee1cc2a2ebfe9384.

For the prefix `tmp`, following key will result with `_key`
```
request: s5cmd ls s3://bucket/tmp
response: tmp_key
prefix: tmp
current output: _key 
expected output: tmp_key
```
This PR fixes this issue.