### PR TITLE
Start workers after validating jobs

### DIFF
--- a/core/job.go
+++ b/core/job.go
@@ -183,12 +183,6 @@ func (j *Job) displayHelp() {
 
 // run runs the Job and returns error.
 func (j *Job) run(wp *WorkerParams) error {
-	if j.opts.Has(opt.Help) {
-		j.displayHelp()
-		return ErrDisplayedHelp
-	}
-
-	var err error
 	cmdFunc, ok := globalCmdRegistry[j.operation]
 	if !ok {
 		return fmt.Errorf("unhandled operation %v", j.operation)
@@ -207,9 +201,7 @@ func (j *Job) Run(wp WorkerParams) *Job {
 		return j.successCommand
 	}
 	if acceptableErr := IsAcceptableError(err); acceptableErr != nil {
-		if acceptableErr != ErrDisplayedHelp {
-			j.PrintOK(acceptableErr)
-		}
+		j.PrintOK(acceptableErr)
 		j.Notify(true)
 		return j.successCommand
 	}

--- a/core/jobargument.go
+++ b/core/jobargument.go
@@ -18,8 +18,6 @@ var (
 	ErrObjectIsNewerButOk = NewAcceptableError("Object is newer or same age")
 	// ErrObjectSizesMatchButOk is used when a destination object size matches the source and opt.IfSizeDiffers is set.
 	ErrObjectSizesMatchButOk = NewAcceptableError("Object size matches")
-	// ErrDisplayedHelp is used when a command is invoked with "-h"
-	ErrDisplayedHelp = NewAcceptableError("Displayed help for command")
 )
 
 // JobArgument is an argument of the job. Can be a file/directory, an s3 url ("s3" is set in this case) or an arbitrary string.

--- a/core/scan.go
+++ b/core/scan.go
@@ -27,14 +27,16 @@ func NewCancelableScanner(ctx context.Context, r io.Reader) *CancelableScanner {
 // Start stats the goroutine on the CancelableScanner and returns itself
 func (s *CancelableScanner) Start() *CancelableScanner {
 	go func() {
+		defer func() {
+			close(s.data)
+			close(s.err)
+		}()
 		for s.Scan() {
 			s.data <- s.Text()
 		}
 		if err := s.Err(); err != nil {
 			s.err <- err
 		}
-		close(s.data)
-		close(s.err)
 	}()
 	return s
 }

--- a/core/worker.go
+++ b/core/worker.go
@@ -144,7 +144,6 @@ func (p *WorkerPool) runWorker(st *stats.Stats, idlingCounter *int32, id int) {
 
 func (p *WorkerPool) parseJob(line string) *Job {
 	job, err := ParseJob(line)
-
 	if err != nil {
 		log.Print(`-ERR "`, line, `": `, err)
 		p.st.Increment(stats.Fail)
@@ -213,7 +212,6 @@ func (p *WorkerPool) RunCmd(commandLine string) {
 
 	// start workers if the job is parsable and not help
 	p.startWorkers()
-
 	p.queueJob(j)
 	if j.operation.IsBatch() {
 		p.pumpJobQueues()

--- a/core/worker.go
+++ b/core/worker.go
@@ -52,7 +52,7 @@ type WorkerParams struct {
 	newClient     ClientFunc
 }
 
-// NewWorkerPool creates a new worker pool and start the workers.
+// NewWorkerPool creates a new worker pool.
 func NewWorkerPool(ctx context.Context, params *WorkerPoolParams, st *stats.Stats) *WorkerPool {
 	newClient := func() (storage.Storage, error) {
 		s3, err := storage.NewS3Storage(storage.S3Opts{
@@ -79,12 +79,15 @@ func NewWorkerPool(ctx context.Context, params *WorkerPoolParams, st *stats.Stat
 		st:          st,
 	}
 
-	for i := 0; i < params.NumWorkers; i++ {
-		p.wg.Add(1)
-		go p.runWorker(st, &p.idlingCounter, i)
-	}
-
 	return p
+}
+
+// startWorkers starts the workers.
+func (p *WorkerPool) startWorkers() {
+	for i := 0; i < p.params.NumWorkers; i++ {
+		p.wg.Add(1)
+		go p.runWorker(p.st, &p.idlingCounter, i)
+	}
 }
 
 // runWorker is the main function of a single worker.
@@ -187,28 +190,40 @@ func (p *WorkerPool) pumpJobQueues() {
 	}
 }
 
+// closeAndWait closes the channel and waits all jobs to finish.
+func (p *WorkerPool) closeAndWait() {
+	close(p.jobQueue)
+	p.wg.Wait()
+}
+
 // RunCmd will run a single command (and subsequent sub-commands) in the worker pool, wait for it to finish, clean up and return.
 func (p *WorkerPool) RunCmd(commandLine string) {
+	defer p.closeAndWait()
+
 	j := p.parseJob(commandLine)
+
+	if j == nil {
+		return
+	}
 
 	if j.opts.Has(opt.Help) {
 		j.displayHelp()
 		return
 	}
 
-	if j != nil {
-		p.queueJob(j)
-		if j.operation.IsBatch() {
-			p.pumpJobQueues()
-		}
-	}
+	// start workers if the job is parsable and not help
+	p.startWorkers()
 
-	close(p.jobQueue)
-	p.wg.Wait()
+	p.queueJob(j)
+	if j.operation.IsBatch() {
+		p.pumpJobQueues()
+	}
 }
 
 // Run runs the commands in filename in the worker pool, on EOF it will wait for all commands to finish, clean up and return.
 func (p *WorkerPool) Run(filename string) {
+	defer p.closeAndWait()
+
 	var r io.ReadCloser
 	var err error
 
@@ -222,6 +237,7 @@ func (p *WorkerPool) Run(filename string) {
 		defer r.Close()
 	}
 
+	p.startWorkers()
 	s := NewCancelableScanner(p.ctx, r).Start()
 
 	var j *Job
@@ -245,7 +261,4 @@ func (p *WorkerPool) Run(filename string) {
 	if isAnyBatch {
 		p.pumpJobQueues()
 	}
-	close(p.jobQueue)
-
-	p.wg.Wait()
 }

--- a/core/worker.go
+++ b/core/worker.go
@@ -210,7 +210,6 @@ func (p *WorkerPool) RunCmd(commandLine string) {
 		return
 	}
 
-	// start workers if the job is parsable and not help
 	p.startWorkers()
 	p.queueJob(j)
 	if j.operation.IsBatch() {

--- a/core/worker.go
+++ b/core/worker.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/peak/s5cmd/opt"
 	"github.com/peak/s5cmd/stats"
 	"github.com/peak/s5cmd/storage"
 )
@@ -140,6 +141,7 @@ func (p *WorkerPool) runWorker(st *stats.Stats, idlingCounter *int32, id int) {
 
 func (p *WorkerPool) parseJob(line string) *Job {
 	job, err := ParseJob(line)
+
 	if err != nil {
 		log.Print(`-ERR "`, line, `": `, err)
 		p.st.Increment(stats.Fail)
@@ -188,6 +190,12 @@ func (p *WorkerPool) pumpJobQueues() {
 // RunCmd will run a single command (and subsequent sub-commands) in the worker pool, wait for it to finish, clean up and return.
 func (p *WorkerPool) RunCmd(commandLine string) {
 	j := p.parseJob(commandLine)
+
+	if j.opts.Has(opt.Help) {
+		j.displayHelp()
+		return
+	}
+
 	if j != nil {
 		p.queueJob(j)
 		if j.operation.IsBatch() {


### PR DESCRIPTION
Currently, workers are running without validating jobs. 

Help command should be isolated from the worker pool. Also, if the jobs are not valid, we should not start workers. This PR makes the following improvements:
 
- Remove `HELP` command from AcceptableErrors.
- Don't send help commands to the job queue.
- Start workers if jobs are parsable and not help.
- Use deferred calls for closing channels.