### PR TITLE
Add --force-path-style flag to use path-style addressing.

### DIFF
--- a/flags/flags.go
+++ b/flags/flags.go
@@ -21,6 +21,7 @@ const (
 var (
 	CommandFile         = flag.String("f", "", "Commands-file or - for stdin")
 	EndpointURL         = flag.String("endpoint-url", "", "Override default URL with the given one")
+	ForcePathStyle      = flag.Bool("force-path-style", false, "Use path-style addressing")
 	WorkerCount         = flag.Int("numworkers", defaultWorkerCount, "Number of worker goroutines. Negative numbers mean multiples of the CPU core count")
 	DownloadConcurrency = flag.Int("dw", defaultDownloadConcurrency, "Download concurrency for each file")
 	DownloadPartSize    = flag.Int64("ds", 50, "Multipart chunk size in MB for downloads")

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -59,6 +59,7 @@ func newS3Factory() func() (*S3, error) {
 			DownloadConcurrency:    *flags.DownloadConcurrency,
 			DownloadChunkSizeBytes: *flags.DownloadPartSize,
 			EndpointURL:            *flags.EndpointURL,
+			ForcePathStyle:         *flags.ForcePathStyle,
 			MaxRetries:             *flags.RetryCount,
 			NoVerifySSL:            *flags.NoVerifySSL,
 			UploadChunkSizeBytes:   *flags.UploadPartSize,
@@ -94,6 +95,7 @@ type S3 struct {
 type S3Opts struct {
 	MaxRetries             int
 	EndpointURL            string
+	ForcePathStyle         bool
 	Region                 string
 	NoVerifySSL            bool
 	UploadChunkSizeBytes   int64
@@ -453,6 +455,7 @@ func (s *S3) UpdateRegion(bucket string) error {
 	ses, err := newSession(S3Opts{
 		MaxRetries:             s.opts.MaxRetries,
 		EndpointURL:            s.opts.EndpointURL,
+		ForcePathStyle:         s.opts.ForcePathStyle,
 		Region:                 aws.StringValue(o.LocationConstraint),
 		NoVerifySSL:            s.opts.NoVerifySSL,
 		DownloadConcurrency:    s.opts.DownloadConcurrency,
@@ -485,7 +488,7 @@ func newSession(opts S3Opts) (*session.Session, error) {
 
 	// use virtual-host style everywhere except localhost. e2e testing becomes
 	// harder if virtual-host style (subdomains) is used.
-	forcePathStyle := false
+	forcePathStyle := opts.ForcePathStyle
 	if isLocalhost(endpoint) {
 		forcePathStyle = true
 	}


### PR DESCRIPTION
Many/most non-AWS object stores only support path-style addressing, but
recent changes switched to virtual-host addressing which broke access to
those object stores. This adds a flag to switch back to path style
addressing.

For more info, a virtual-host address looks like "http://bucketname.endpoint",
resulting in a DNS lookup. Path-style addressing looks like
"http://endpoint/bucketname" instead. The benefit of path-style
addressing is simplicity; you do not need to interact with DNS servers.