### PR TITLE
Use virtual-style if the endpoint is known to has support

### DIFF
--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -39,12 +39,12 @@ func TestNewSessionPathStyle(t *testing.T) {
 			expectPathStyle: false,
 		},
 		{
-			name:            "expect_path_host_style_for_localhost",
+			name:            "expect_path_style_for_localhost",
 			endpoint:        url.URL{Host: "127.0.0.1"},
 			expectPathStyle: true,
 		},
 		{
-			name:            "expect_path_host_style_for_custom_endpoint",
+			name:            "expect_path_style_for_custom_endpoint",
 			endpoint:        url.URL{Host: "example.com"},
 			expectPathStyle: true,
 		},


### PR DESCRIPTION
Amazon S3, S3 Transfer Acceleration and Google Cloud Storage known to support virtual-style bucket resolve method. For other types of endpoints, such as custom object store or localhost, use path-style bucket name resolve method.

Related: #92