### PR TITLE
storage: Remove maxKeys parameter from List

### DIFF
--- a/command/cmd_copy.go
+++ b/command/cmd_copy.go
@@ -625,7 +625,7 @@ func expandSource(
 
 	// call storage.List for only walking operations.
 	if srcurl.HasGlob() || isDir {
-		return client.List(ctx, srcurl, isRecursive, storage.ListAllItems), nil
+		return client.List(ctx, srcurl, isRecursive), nil
 	}
 
 	ch := make(chan *storage.Object, 1)

--- a/command/cmd_list.go
+++ b/command/cmd_list.go
@@ -92,7 +92,7 @@ func List(
 
 	var merror error
 
-	for object := range client.List(ctx, srcurl, true, storage.ListAllItems) {
+	for object := range client.List(ctx, srcurl, true) {
 		if errorpkg.IsCancelation(object.Err) {
 			continue
 		}

--- a/command/cmd_size.go
+++ b/command/cmd_size.go
@@ -72,7 +72,7 @@ func Size(
 
 	var merror error
 
-	for object := range client.List(ctx, srcurl, true, storage.ListAllItems) {
+	for object := range client.List(ctx, srcurl, true) {
 		if object.Type.IsDir() || errorpkg.IsCancelation(object.Err) {
 			continue
 		}

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -39,7 +39,7 @@ func (f *Filesystem) Stat(ctx context.Context, url *objurl.ObjectURL) (*Object, 
 	}, nil
 }
 
-func (f *Filesystem) List(ctx context.Context, url *objurl.ObjectURL, isRecursive bool, _ int64) <-chan *Object {
+func (f *Filesystem) List(ctx context.Context, url *objurl.ObjectURL, isRecursive bool) <-chan *Object {
 	obj, err := f.Stat(ctx, url)
 	isDir := err == nil && obj.Type.IsDir()
 

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -145,7 +145,7 @@ func TestS3_List_success(t *testing.T) {
 	}
 
 	index := 0
-	for got := range mockS3.List(context.Background(), url, true, ListAllItems) {
+	for got := range mockS3.List(context.Background(), url, true) {
 		if got.Err != nil {
 			t.Errorf("unexpected error: %v", got.Err)
 		}
@@ -184,7 +184,7 @@ func TestS3_List_error(t *testing.T) {
 		r.Error = mockErr
 	})
 
-	for got := range mockS3.List(context.Background(), url, true, ListAllItems) {
+	for got := range mockS3.List(context.Background(), url, true) {
 		if got.Err != mockErr {
 			t.Errorf("error got = %v, want %v", got.Err, mockErr)
 		}
@@ -221,7 +221,7 @@ func TestS3_List_no_item_found(t *testing.T) {
 		}
 	})
 
-	for got := range mockS3.List(context.Background(), url, true, ListAllItems) {
+	for got := range mockS3.List(context.Background(), url, true) {
 		if got.Err != ErrNoObjectFound {
 			t.Errorf("error got = %v, want %v", got.Err, ErrNoObjectFound)
 		}
@@ -255,7 +255,7 @@ func TestS3_List_context_cancelled(t *testing.T) {
 		}
 	})
 
-	for got := range mockS3.List(ctx, url, true, ListAllItems) {
+	for got := range mockS3.List(ctx, url, true) {
 		reqErr, ok := got.Err.(awserr.Error)
 		if !ok {
 			t.Errorf("could not convert error")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,7 +30,7 @@ type Storage interface {
 	// List the objects and directories/prefixes in the src. If recursive
 	// argument is given, given src will be walked if src is a walkable URL,
 	// such as directory, prefix or a wildcard.
-	List(ctx context.Context, src *objurl.ObjectURL, recursive bool, maxitems int64) <-chan *Object
+	List(ctx context.Context, src *objurl.ObjectURL, recursive bool) <-chan *Object
 
 	// Copy src to dst, optionally setting the given metadata. Src and dst
 	// arguments are of the same type. If src is a remote type, server side


### PR DESCRIPTION
We are using a full scan mode on storage.List() operations and do not need maxKeys param for this release. It was used by s3 predictor. Once we decided to reimplement it, we can add this parameter again. 