### PR TITLE
storage/s3: add custom retryer for custom error codes

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -619,14 +619,13 @@ func newSession(opts S3Options) (*session.Session, error) {
 }
 
 type requestRetryer struct {
-	*client.DefaultRetryer
+	client.DefaultRetryer
+	maxRetries int
 }
 
 func newRequestRetryer(maxRetries int) *requestRetryer {
 	return &requestRetryer{
-		DefaultRetryer: &client.DefaultRetryer{
-			NumMaxRetries: maxRetries,
-		},
+		maxRetries: maxRetries,
 	}
 }
 
@@ -636,6 +635,10 @@ func (r *requestRetryer) ShouldRetry(req *request.Request) bool {
 	}
 	return r.DefaultRetryer.ShouldRetry(req)
 
+}
+
+func (r *requestRetryer) MaxRetries() int {
+	return r.maxRetries
 }
 
 var insecureHTTPClient = &http.Client{

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -639,7 +639,6 @@ func (c *CustomRetryer) ShouldRetry(req *request.Request) bool {
 		return true
 	}
 	return c.DefaultRetryer.ShouldRetry(req)
-
 }
 
 var insecureHTTPClient = &http.Client{


### PR DESCRIPTION
We occasionally receive InternalError codes from S3 API. It was on our retry list before.

Adding a custom retryer that implements request.Retryer interface.