### PR TITLE
storage/s3: allow any storage-class value

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -131,7 +131,7 @@ var copyCommand = &cli.Command{
 			ifSourceNewer:  c.Bool("if-source-newer"),
 			flatten:        c.Bool("flatten"),
 			followSymlinks: !c.Bool("no-follow-symlinks"),
-			storageClass:   storage.LookupClass(c.String("storage-class")),
+			storageClass:   storage.StorageClass(c.String("storage-class")),
 			concurrency:    c.Int("concurrency"),
 			partSize:       c.Int64("part-size") * megabytes,
 		}.Run(c.Context)
@@ -214,7 +214,7 @@ func (c Copy) Run(ctx context.Context) error {
 			continue
 		}
 
-		if object.StorageClass == storage.StorageGlacier {
+		if object.StorageClass.IsGlacier() {
 			err := fmt.Errorf("object '%v' is on Glacier storage", object)
 			printError(c.fullCommand, c.op, err)
 			continue
@@ -586,11 +586,6 @@ func getObject(ctx context.Context, url *url.URL) (*storage.Object, error) {
 func validate(c *cli.Context) error {
 	if c.Args().Len() != 2 {
 		return fmt.Errorf("expected source and destination arguments")
-	}
-
-	storageClass := storage.LookupClass(c.String("storage-class"))
-	if storageClass == storage.StorageInvalid {
-		return fmt.Errorf("invalid storage class")
 	}
 
 	ctx := c.Context

--- a/command/ls.go
+++ b/command/ls.go
@@ -159,11 +159,11 @@ const (
 
 // String returns the string representation of ListMessage.
 func (l ListMessage) String() string {
-	var listFormat = "%19s %1s %-1s %12s %s"
+	var listFormat = "%19s %2s %-1s %12s %s"
 	var etag string
 	if l.showEtag {
 		etag = l.Object.Etag
-		listFormat = "%19s %1s %-38s %12s %s"
+		listFormat = "%19s %2s %-38s %12s %s"
 	}
 
 	if l.Object.Type.IsDir() {

--- a/command/mv.go
+++ b/command/mv.go
@@ -52,7 +52,7 @@ var moveCommand = &cli.Command{
 			ifSizeDiffer:  c.Bool("if-size-differ"),
 			ifSourceNewer: c.Bool("if-source-newer"),
 			flatten:       c.Bool("flatten"),
-			storageClass:  storage.LookupClass(c.String("storage-class")),
+			storageClass:  storage.StorageClass(c.String("storage-class")),
 		}
 
 		return copyCommand.Run(c.Context)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -737,8 +737,7 @@ func TestCopySingleFileToS3JSON(t *testing.T) {
 			"destination": "s3://%v/testfile1.txt",
 			"object": {
 				"type": "file",
-				"size":19,
-				"storage_class": "STANDARD"
+				"size":19
 			}
 		}
 	`
@@ -1373,8 +1372,7 @@ func TestCopySingleS3ObjectToS3JSON(t *testing.T) {
 			"destination":"%v",
 			"object": {
 				"key": "%v",
-				"type":"file",
-				"storage_class":"STANDARD"
+				"type":"file"
 			}
 		}
 	`, src, dst, dst)
@@ -1727,8 +1725,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/readme.md",
 				"object": {
 					"key": "s3://%v/dst/readme.md",
-					"type": "file",
-					"storage_class": "STANDARD"
+					"type": "file"
 				}
 			}
 		`, bucket, bucket, bucket),
@@ -1740,8 +1737,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/testfile1.txt",
 				"object": {
 					"key": "s3://%v/dst/testfile1.txt",
-					"type": "file",
-					"storage_class": "STANDARD"
+					"type": "file"
 				}
 			}
 		`, bucket, bucket, bucket),

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -184,7 +184,8 @@ func createBucket(t *testing.T, client *s3.S3, bucket string) {
 var errS3NoSuchKey = fmt.Errorf("s3: no such key")
 
 type ensureOpts struct {
-	contentType *string
+	contentType  *string
+	storageClass *string
 }
 
 type ensureOption func(*ensureOpts)
@@ -192,6 +193,12 @@ type ensureOption func(*ensureOpts)
 func ensureContentType(contentType string) ensureOption {
 	return func(opts *ensureOpts) {
 		opts.contentType = &contentType
+	}
+}
+
+func ensureStorageClass(expected string) ensureOption {
+	return func(opts *ensureOpts) {
+		opts.storageClass = &expected
 	}
 }
 
@@ -235,7 +242,13 @@ func ensureS3Object(
 
 	if opts.contentType != nil {
 		if diff := cmp.Diff(opts.contentType, output.ContentType); diff != "" {
-			return fmt.Errorf("s3 %v/%v: (-want +got):\n%v", bucket, key, diff)
+			return fmt.Errorf("content-type of %v/%v: (-want +got):\n%v", bucket, key, diff)
+		}
+	}
+
+	if opts.storageClass != nil {
+		if diff := cmp.Diff(opts.storageClass, output.StorageClass); diff != "" {
+			return fmt.Errorf("storage-class of %v/%v: (-want +got):\n%v", bucket, key, diff)
 		}
 	}
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -353,23 +353,25 @@ func (s *S3) Put(
 	concurrency int,
 	partSize int64,
 ) error {
-	storageClass := metadata["StorageClass"]
-	if storageClass == "" {
-		storageClass = string(StorageStandard)
-	}
 
 	contentType := metadata["ContentType"]
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
 
-	_, err := s.uploader.UploadWithContext(ctx, &s3manager.UploadInput{
-		Bucket:       aws.String(to.Bucket),
-		Key:          aws.String(to.Path),
-		Body:         reader,
-		ContentType:  aws.String(contentType),
-		StorageClass: aws.String(storageClass),
-	}, func(u *s3manager.Uploader) {
+	input := &s3manager.UploadInput{
+		Bucket:      aws.String(to.Bucket),
+		Key:         aws.String(to.Path),
+		Body:        reader,
+		ContentType: aws.String(contentType),
+	}
+
+	storageClass := metadata["StorageClass"]
+	if storageClass != "" {
+		input.StorageClass = aws.String(storageClass)
+	}
+
+	_, err := s.uploader.UploadWithContext(ctx, input, func(u *s3manager.Uploader) {
 		u.PartSize = partSize
 		u.Concurrency = concurrency
 	})

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -161,57 +161,33 @@ func (b Bucket) JSON() string {
 // StorageClass represents the storage used to store an object.
 type StorageClass string
 
-// ShortCode returns the short code of Storage Class.
+// ShortCode returns the short code of Amazon S3 Storage Class.
 func (s StorageClass) ShortCode() string {
 	var code string
 	switch s {
-	case StorageStandard:
-		code = ""
-	case StorageGlacier:
-		code = "G"
-	case StorageReducedRedundancy:
-		code = "R"
-	case StorageStandardIA:
-		code = "I"
+	case "STANDARD":
+		code = "ST"
+	case "REDUCED_REDUNDANCY":
+		code = "RR"
+	case "STANDARD_IA":
+		code = "SI"
+	case "ONEZONE_IA":
+		code = "OI"
+	case "INTELLIGENT_TIERING":
+		code = "IT"
+	case "GLACIER":
+		code = "GL"
+	case "DEEP_ARCHIVE":
+		code = "DA"
 	default:
-		code = "?"
+		code = " ?"
 	}
 	return code
 }
 
-// LookupClass looks up given class.
-func LookupClass(s string) StorageClass {
-	switch s {
-	case "", "STANDARD":
-		return StorageStandard
-	case "REDUCED_REDUNDANCY":
-		return StorageReducedRedundancy
-	case "GLACIER":
-		return StorageGlacier
-	case "STANDARD_IA":
-		return StorageStandardIA
-	default:
-		return StorageInvalid
-	}
+func (s StorageClass) IsGlacier() bool {
+	return s == "GLACIER"
 }
-
-const (
-	// StorageInvalid is a placeholder class if the class is not valid.
-	StorageInvalid StorageClass = "UNKNOWN"
-
-	// StorageStandard is a standard storage class type.
-	StorageStandard StorageClass = "STANDARD"
-
-	// StorageReducedRedundancy is a reduced redundancy storage class type.
-	StorageReducedRedundancy StorageClass = "REDUCED_REDUNDANCY"
-
-	// StorageGlacier is a glacier storage class type.
-	StorageGlacier StorageClass = "GLACIER"
-
-	// StorageStandardIA is a Standard Infrequent-Access storage
-	// class type.
-	StorageStandardIA StorageClass = "STANDARD_IA"
-)
 
 // notImplemented is a structure which is used on the unsupported operations.
 type notImplemented struct {


### PR DESCRIPTION
- e2e/cp: add --storage-class=GLACIER test
- also show 2 character storage class short code in 'ls' output

If you pass an invalid storage class, S3 will return:

```
s5cmd cp --storage-class=invalidstorageclass file s3://bucket/
ERROR "cp file s3://bucket/file": InvalidStorageClass: The storage class you specified is not valid status code: 400...
```

Fixes #160