### PR TITLE
cp: Set storage class if provided

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -22,6 +22,7 @@ import (
 const (
 	defaultCopyConcurrency = 5
 	defaultPartSize        = 50 // MiB
+	defaultStorageClass    = "STANDARD"
 	megabytes              = 1024 * 1024
 )
 
@@ -93,9 +94,9 @@ var copyCommandFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "storage-class",
+		Value:       defaultStorageClass,
+		DefaultText: defaultStorageClass,
 		Usage:       "set storage class for target ('STANDARD','REDUCED_REDUNDANCY','GLACIER','STANDARD_IA','ONEZONE_IA','INTELLIGENT_TIERING','DEEP_ARCHIVE')",
-		Value:       "STANDARD",
-		DefaultText: "STANDARD",
 	},
 	&cli.IntFlag{
 		Name:    "concurrency",

--- a/command/cp.go
+++ b/command/cp.go
@@ -22,7 +22,6 @@ import (
 const (
 	defaultCopyConcurrency = 5
 	defaultPartSize        = 50 // MiB
-	defaultStorageClass    = "STANDARD"
 	megabytes              = 1024 * 1024
 )
 
@@ -93,10 +92,8 @@ var copyCommandFlags = []cli.Flag{
 		Usage: "do not follow symbolic links",
 	},
 	&cli.StringFlag{
-		Name:        "storage-class",
-		Value:       defaultStorageClass,
-		DefaultText: defaultStorageClass,
-		Usage:       "set storage class for target ('STANDARD','REDUCED_REDUNDANCY','GLACIER','STANDARD_IA','ONEZONE_IA','INTELLIGENT_TIERING','DEEP_ARCHIVE')",
+		Name:  "storage-class",
+		Usage: "set storage class for target ('STANDARD','REDUCED_REDUNDANCY','GLACIER','STANDARD_IA','ONEZONE_IA','INTELLIGENT_TIERING','DEEP_ARCHIVE')",
 	},
 	&cli.IntFlag{
 		Name:    "concurrency",

--- a/command/cp.go
+++ b/command/cp.go
@@ -92,8 +92,10 @@ var copyCommandFlags = []cli.Flag{
 		Usage: "do not follow symbolic links",
 	},
 	&cli.StringFlag{
-		Name:  "storage-class",
-		Usage: "set storage class for target ('STANDARD','REDUCED_REDUNDANCY','GLACIER','STANDARD_IA')",
+		Name:        "storage-class",
+		Usage:       "set storage class for target ('STANDARD','REDUCED_REDUNDANCY','GLACIER','STANDARD_IA','ONEZONE_IA','INTELLIGENT_TIERING','DEEP_ARCHIVE')",
+		Value:       "STANDARD",
+		DefaultText: "STANDARD",
 	},
 	&cli.IntFlag{
 		Name:    "concurrency",

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -737,7 +737,8 @@ func TestCopySingleFileToS3JSON(t *testing.T) {
 			"destination": "s3://%v/testfile1.txt",
 			"object": {
 				"type": "file",
-				"size":19
+				"size":19,
+				"storage_class":"STANDARD"
 			}
 		}
 	`
@@ -1413,7 +1414,8 @@ func TestCopySingleS3ObjectToS3JSON(t *testing.T) {
 			"destination":"%v",
 			"object": {
 				"key": "%v",
-				"type":"file"
+				"type":"file",
+				"storage_class":"STANDARD"
 			}
 		}
 	`, src, dst, dst)
@@ -1766,7 +1768,8 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/readme.md",
 				"object": {
 					"key": "s3://%v/dst/readme.md",
-					"type": "file"
+					"type": "file",
+					"storage_class":"STANDARD"
 				}
 			}
 		`, bucket, bucket, bucket),
@@ -1778,7 +1781,8 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/testfile1.txt",
 				"object": {
 					"key": "s3://%v/dst/testfile1.txt",
-					"type": "file"
+					"type": "file",
+					"storage_class":"STANDARD"
 				}
 			}
 		`, bucket, bucket, bucket),

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -737,8 +737,7 @@ func TestCopySingleFileToS3JSON(t *testing.T) {
 			"destination": "s3://%v/testfile1.txt",
 			"object": {
 				"type": "file",
-				"size":19,
-				"storage_class":"STANDARD"
+				"size":19
 			}
 		}
 	`
@@ -1414,8 +1413,7 @@ func TestCopySingleS3ObjectToS3JSON(t *testing.T) {
 			"destination":"%v",
 			"object": {
 				"key": "%v",
-				"type":"file",
-				"storage_class":"STANDARD"
+				"type":"file"
 			}
 		}
 	`, src, dst, dst)
@@ -1768,8 +1766,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/readme.md",
 				"object": {
 					"key": "s3://%v/dst/readme.md",
-					"type": "file",
-					"storage_class":"STANDARD"
+					"type": "file"
 				}
 			}
 		`, bucket, bucket, bucket),
@@ -1781,8 +1778,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 				"destination": "s3://%v/dst/testfile1.txt",
 				"object": {
 					"key": "s3://%v/dst/testfile1.txt",
-					"type": "file",
-					"storage_class":"STANDARD"
+					"type": "file"
 				}
 			}
 		`, bucket, bucket, bucket),

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -353,7 +353,6 @@ func (s *S3) Put(
 	concurrency int,
 	partSize int64,
 ) error {
-
 	contentType := metadata["ContentType"]
 	if contentType == "" {
 		contentType = "application/octet-stream"

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -300,14 +300,18 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata map[string]st
 	// SDK expects CopySource like "bucket[/key]"
 	copySource := strings.TrimPrefix(from.String(), "s3://")
 
-	storageClass := metadata["StorageClass"]
+	input := &s3.CopyObjectInput{
+		Bucket:     aws.String(to.Bucket),
+		Key:        aws.String(to.Path),
+		CopySource: aws.String(copySource),
+	}
 
-	_, err := s.api.CopyObject(&s3.CopyObjectInput{
-		Bucket:       aws.String(to.Bucket),
-		Key:          aws.String(to.Path),
-		CopySource:   aws.String(copySource),
-		StorageClass: aws.String(storageClass),
-	})
+	storageClass := metadata["StorageClass"]
+	if storageClass != "" {
+		input.StorageClass = aws.String(storageClass)
+	}
+
+	_, err := s.api.CopyObject(input)
 	return err
 }
 


### PR DESCRIPTION
If we don't provide `--storage-class` flag, cp gives InvalidStorageClass error on the master branch. I think it should be useful to give a default value for this flag. Also, updated usage to include new storage class types.