### PR TITLE
Replace obsolete global option value in app.go

### DIFF
--- a/command/app.go
+++ b/command/app.go
@@ -49,7 +49,7 @@ var app = &cli.App{
 		&cli.StringFlag{
 			Name:  "log",
 			Value: "info",
-			Usage: "log level: (verbose, info, error)",
+			Usage: "log level: (debug, info, error)",
 		},
 		&cli.BoolFlag{
 			Name:  "install-completion",


### PR DESCRIPTION
Replace obsolete global option value in app.go

The value `verbose` for global option `--log` has been deprecated in favor of `debug`. This fixes #173 .