### PR TITLE
ci: add Github Actions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+on: [pull_request]
+name: CI
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version:
+          - 1.14.4
+          - 1.13.12
+        os:
+          - macos
+          - ubuntu
+          - windows
+
+    name: build (${{ matrix.os }}/go-${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - run: go build -mod=vendor .
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.4
+
+    - run: make test
+
+  qa:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.4
+
+    - run: make check-fmt
+    - run: make vet
+    - run: go get honnef.co/go/tools/cmd/staticcheck
+    - run: make staticcheck
+    - run: go get mvdan.cc/unparam
+    - run: make unparam

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 
 .PHONY: test
 test:
-	@go test -mod=vendor ./...
+	@go test -mod=vendor -count=1 ./...
 
 .PHONY: check
 check: vet staticcheck unparam check-fmt


### PR DESCRIPTION
- Add Windows build support
- Add macOS build support
- Use a build matrix to run jobs for multiple operating systems and Go versions

Fixes #95