### PR TITLE
Retry on closed connection

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -690,7 +690,6 @@ func errContains(err error, msg string) bool {
 	}
 
 	return false
-
 }
 
 // IsCancelationError reports whether given error is a storage related

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -284,6 +284,10 @@ func TestS3Retry(t *testing.T) {
 			err:  awserr.New(request.ErrCodeRequestError, "request error", nil),
 		},
 		{
+			name: "RequestError",
+			err:  awserr.New(request.ErrCodeRequestError, "use of closed network connection", nil),
+		},
+		{
 			name: "RequestFailureRequestError",
 			err: awserr.NewRequestFailure(
 				awserr.New(request.ErrCodeRequestError, "request failure: request error", nil),

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -284,7 +284,7 @@ func TestS3Retry(t *testing.T) {
 			err:  awserr.New(request.ErrCodeRequestError, "request error", nil),
 		},
 		{
-			name: "RequestError",
+			name: "UseOfClosedNetworkConnection",
 			err:  awserr.New(request.ErrCodeRequestError, "use of closed network connection", nil),
 		},
 		{


### PR DESCRIPTION
We upload large amount of data to s3 and after upgrading version 1.0.0 ,  we experienced failures for large uploads , randomly we get errors like below.

`RequestError: send request failed
caused by: Put "https://testing.s3.amazonaws.com/xxxxx&partNumber=n&uploadId=id": write tcp 10.xx.xx.xx:41654->52.216.8.115:443: use of closed network connection`

After digging AWS SDK `ShouldRetry` method, we noticed that for some cases it does return `false` but for some cases it returns `true` even if base error says `use of closed network connection` in both cases, you can see below

`SerializationError: failed to unmarshal error message
        status code: 500, request id: IDDDDDDD, host id: 3231sdsadasdasdI=
caused by: UnmarshalError: failed to unmarshal error message
caused by: read tcp 10.xx.xx.xx:39860->52.216.166.67:443: use of closed network connection: true`

`RequestError: send request failed
caused by: Put "https://testing.s3.amazonaws.com/xxxx?partNumber=n&uploadId=id--": write tcp 10.xx.xx.xx:41654->52.216.8.115:443: use of closed network connection: false`

So we implemented this patch to retry on any error that contains `use of closed network connection` ,  as golang does not export this error `https://github.com/golang/go/issues/4373` , we had to check error msg.