### PR TITLE
command/{expand, expand_test}, e2e/{cp, rm, run}: fixed rm operation issue on non-existent file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,7 @@ jobs:
     - run: make test
 
   qa:
-    strategy:
-      matrix:
-        os:
-          - macos
-          - ubuntu
-          - windows
-
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 #### Bugfixes
 
+- Fixed rm operation issue, where removing a nonexistent object returned success. ([#69](https://github.com/peak/s5cmd/issues/69))
 - Fixed windows filepath issue, where backslashes should be treated as the path delimiter. ([#178](https://github.com/peak/s5cmd/issues/178))
 - All tests pass on windows, by converting and treating file paths to UNIX filepath format.
 - Fixed a transfer issue where the object path contains particular regex metacharacters. ([#111](https://github.com/peak/s5cmd/pull/111)) [@brendan-matroid](https://github.com/brendan-matroid)

--- a/command/expand.go
+++ b/command/expand.go
@@ -29,8 +29,10 @@ func expandSource(
 		isDir = obj.Type.IsDir()
 	}
 
-	// call storage.List for only walking operations.
-	if srcurl.HasGlob() || isDir {
+	// call storage.List for only walking operations
+	// or remote operations, since for the remote operations
+	// we would like to know if the object exists.
+	if srcurl.HasGlob() || isDir || srcurl.IsRemote() {
 		return client.List(ctx, srcurl, followSymlinks), nil
 	}
 
@@ -72,9 +74,6 @@ func expandSources(
 				}
 
 				for object := range objch {
-					if object.Err == storage.ErrNoObjectFound {
-						continue
-					}
 					ch <- object
 					objFound = true
 				}

--- a/command/expand_test.go
+++ b/command/expand_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/fs"
 
-	"github.com/stretchr/testify/mock"
-
 	"github.com/peak/s5cmd/storage"
 	"github.com/peak/s5cmd/storage/url"
 )
@@ -108,6 +106,7 @@ func TestExpandSources(t *testing.T) {
 				"s3://bucket/file1.txt",
 				"s3://bucket/file2.txt",
 			},
+			wantError: storage.ErrNoObjectFound,
 		},
 		{
 			// if multiple source has no item.
@@ -151,9 +150,7 @@ func TestExpandSources(t *testing.T) {
 
 				ch := generateObjects(objects)
 
-				if src != "s3://bucket/key" {
-					client.On("List", mock.Anything, srcurl, mock.Anything).Once().Return(ch)
-				}
+				client.On("List", context.Background(), srcurl, false).Once().Return(ch)
 			}
 
 			gotChan := expandSources(context.Background(), client, false, srcurls...)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -838,7 +838,6 @@ func TestCopyDirBackslashedToS3(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: equals(`cp %v/readme.md %vreadme.md`, srcpath, dstpath),
 		1: equals(`cp %v/t\est/filetest.txt %vt\est/filetest.txt`, srcpath, dstpath),

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -66,7 +66,7 @@ func TestRunFromStdinWithErrors(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
-		0: contains(`ERROR "cp s3://%v/nonexistentobject nonexistentobject": NoSuchKey: status code: 404`, bucket),
+		0: contains(`ERROR "cp s3://%v/nonexistentobject .": no object found`, bucket),
 		1: equals(`ERROR "ls s3/": given object not found`),
 	}, sortInput(true))
 }


### PR DESCRIPTION
Resolves #69 