### PR TITLE
goreleaser: disable before hooks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - make
+    #- make
 builds:
   -
     binary: s5cmd


### PR DESCRIPTION
Test cases with wildcards and List calls are flaky due to gofakes3 with the changes in #188. Disabling before hooks until it is fixed.