### PR TITLE
command/cp: remove misleading "mirroring" in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - AWS S3 `RequestTimeTooSkewed` request error was not retryable before, it is now. ([205](https://github.com/peak/s5cmd/issues/205))
 - For some operations errors were printed at the end of the program execution. Now, errors are displayed immediately after being detected. ([#136](https://github.com/peak/s5cmd/issues/136))
 - From now on, docker images will be published on Docker Hub. ([#238](https://github.com/peak/s5cmd/issues/238))
+- Changed misleading 'mirroring' examples in the help text of `cp`. ([#213](https://github.com/peak/s5cmd/issues/213))
 
 #### Bugfixes
 - Fixed incorrect MIME type inference for `cp`, give priority to file extension for type inference. ([#214](https://github.com/peak/s5cmd/issues/214))

--- a/command/cp.go
+++ b/command/cp.go
@@ -65,7 +65,7 @@ Examples:
 	09. Copy files in a directory to S3 prefix if not found on target
 		 > s5cmd {{.HelpName}} -n -s -u dir/ s3://bucket/target-prefix/
 
-	10. Copy files in a S3 prefix to another S3 prefix if not found on target
+	10. Copy files in an S3 prefix to another S3 prefix if not found on target
 		 > s5cmd {{.HelpName}} -n -s -u s3://bucket/source-prefix/* s3://bucket/target-prefix/
 
 	11. Perform KMS Server Side Encryption of the object(s) at the destination

--- a/command/cp.go
+++ b/command/cp.go
@@ -62,10 +62,10 @@ Examples:
 	08. Copy matching S3 objects to another bucket
 		 > s5cmd {{.HelpName}} s3://bucket/*.gz s3://target-bucket/prefix/
 
-	09. Mirror a directory to target S3 prefix
+	09. Copy files in a directory to S3 prefix if not found on target
 		 > s5cmd {{.HelpName}} -n -s -u dir/ s3://bucket/target-prefix/
 
-	10. Mirror an S3 prefix to target S3 prefix
+	10. Copy files in a S3 prefix to another S3 prefix if not found on target
 		 > s5cmd {{.HelpName}} -n -s -u s3://bucket/source-prefix/* s3://bucket/target-prefix/
 
 	11. Perform KMS Server Side Encryption of the object(s) at the destination


### PR DESCRIPTION
Resolves #213 