### PR TITLE
storage/s3: don't fail early if there are any auto-fetch errors during session init

### DIFF
--- a/log/message.go
+++ b/log/message.go
@@ -7,23 +7,19 @@ import (
 	"github.com/peak/s5cmd/strutil"
 )
 
-type JSONMarshaler interface {
-	JSON() string
-}
-
 // Message is an interface to print structured logs.
 type Message interface {
 	fmt.Stringer
-	JSONMarshaler
+	JSON() string
 }
 
 // InfoMessage is a generic message structure for successful operations.
 type InfoMessage struct {
-	Operation   string        `json:"operation"`
-	Success     bool          `json:"success"`
-	Source      *url.URL      `json:"source"`
-	Destination *url.URL      `json:"destination,omitempty"`
-	Object      JSONMarshaler `json:"object,omitempty"`
+	Operation   string   `json:"operation"`
+	Success     bool     `json:"success"`
+	Source      *url.URL `json:"source"`
+	Destination *url.URL `json:"destination,omitempty"`
+	Object      Message  `json:"object,omitempty"`
 }
 
 // String is the string representation of InfoMessage.

--- a/log/message.go
+++ b/log/message.go
@@ -3,24 +3,27 @@ package log
 import (
 	"fmt"
 
-	"github.com/peak/s5cmd/storage"
 	"github.com/peak/s5cmd/storage/url"
 	"github.com/peak/s5cmd/strutil"
 )
 
+type JSONMarshaler interface {
+	JSON() string
+}
+
 // Message is an interface to print structured logs.
 type Message interface {
 	fmt.Stringer
-	JSON() string
+	JSONMarshaler
 }
 
 // InfoMessage is a generic message structure for successful operations.
 type InfoMessage struct {
-	Operation   string          `json:"operation"`
-	Success     bool            `json:"success"`
-	Source      *url.URL        `json:"source"`
-	Destination *url.URL        `json:"destination,omitempty"`
-	Object      *storage.Object `json:"object,omitempty"`
+	Operation   string        `json:"operation"`
+	Success     bool          `json:"success"`
+	Source      *url.URL      `json:"source"`
+	Destination *url.URL      `json:"destination,omitempty"`
+	Object      JSONMarshaler `json:"object,omitempty"`
 }
 
 // String is the string representation of InfoMessage.

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -604,8 +604,8 @@ func (s *S3) MakeBucket(ctx context.Context, name string) error {
 	return err
 }
 
-// s3Session holds session.Session according to s3Opts
-// and it synchronizes access/modification.
+// SessionCache holds session.Session according to s3Opts and it synchronizes
+// access/modification.
 type SessionCache struct {
 	sync.Mutex
 	sessions map[Options]*session.Session

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -43,7 +43,7 @@ const (
 )
 
 // Re-used AWS sessions dramatically improve performance.
-var sessionProvider = &s3Session{
+var globalSessionCache = &SessionCache{
 	sessions: map[Options]*session.Session{},
 }
 
@@ -81,7 +81,7 @@ func newS3Storage(ctx context.Context, opts Options) (*S3, error) {
 		return nil, err
 	}
 
-	awsSession, err := sessionProvider.newSession(ctx, opts)
+	awsSession, err := globalSessionCache.newSession(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -606,18 +606,18 @@ func (s *S3) MakeBucket(ctx context.Context, name string) error {
 
 // s3Session holds session.Session according to s3Opts
 // and it synchronizes access/modification.
-type s3Session struct {
+type SessionCache struct {
 	sync.Mutex
 	sessions map[Options]*session.Session
 }
 
 // newSession initializes a new AWS session with region fallback and custom
 // options.
-func (s *s3Session) newSession(ctx context.Context, opts Options) (*session.Session, error) {
-	s.Lock()
-	defer s.Unlock()
+func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.Session, error) {
+	sc.Lock()
+	defer sc.Unlock()
 
-	if sess, ok := s.sessions[opts]; ok {
+	if sess, ok := sc.sessions[opts]; ok {
 		return sess, nil
 	}
 
@@ -675,40 +675,49 @@ func (s *s3Session) newSession(ctx context.Context, opts Options) (*session.Sess
 		return nil, err
 	}
 
-	if aws.StringValue(sess.Config.Region) == "" {
-		sess.Config.Region = aws.String(endpoints.UsEast1RegionID)
-	}
-
 	// get region of the bucket and create session accordingly. if the region
 	// is not provided, it means we want region-independent session
 	// for operations such as listing buckets, making a new bucket etc.
-	if opts.bucket != "" {
-		region, err := s3manager.GetBucketRegion(ctx, sess, opts.bucket, "", func(r *request.Request) {
-			r.Config.Credentials = sess.Config.Credentials
-		})
-		if err != nil {
-			if errHasCode(err, "NotFound") {
-				return nil, err
-			}
-			// don't deny any request to the service if region auto-fetching
-			// receives an error. Delegate error handling to command execution.
-			err = fmt.Errorf("session: fetching region failed: %v", err)
-			msg := log.ErrorMessage{Err: err.Error()}
-			log.Error(msg)
-		} else {
-			sess.Config.Region = aws.String(region)
-		}
+	if err := setSessionRegion(ctx, sess, opts.bucket); err != nil {
+		return nil, err
 	}
 
-	s.sessions[opts] = sess
+	sc.sessions[opts] = sess
 
 	return sess, nil
 }
 
-func (s *s3Session) clear() {
-	s.Lock()
-	defer s.Unlock()
-	s.sessions = map[Options]*session.Session{}
+func (sc *SessionCache) clear() {
+	sc.Lock()
+	defer sc.Unlock()
+	sc.sessions = map[Options]*session.Session{}
+}
+
+func setSessionRegion(ctx context.Context, sess *session.Session, bucket string) error {
+	if aws.StringValue(sess.Config.Region) == "" {
+		sess.Config.Region = aws.String(endpoints.UsEast1RegionID)
+	}
+
+	if bucket == "" {
+		return nil
+	}
+
+	region, err := s3manager.GetBucketRegion(ctx, sess, bucket, "", func(r *request.Request) {
+		r.Config.Credentials = sess.Config.Credentials
+	})
+	if err != nil {
+		if errHasCode(err, "NotFound") {
+			return err
+		}
+		// don't deny any request to the service if region auto-fetching
+		// receives an error. Delegate error handling to command execution.
+		err = fmt.Errorf("session: fetching region failed: %v", err)
+		msg := log.ErrorMessage{Err: err.Error()}
+		log.Error(msg)
+	} else {
+		sess.Config.Region = aws.String(region)
+	}
+	return nil
 }
 
 // customRetryer wraps the SDK's built in DefaultRetryer adding additional
@@ -725,8 +734,8 @@ func newCustomRetryer(maxRetries int) *customRetryer {
 	}
 }
 
-// ShouldRetry overrides the SDK's built in DefaultRetryer adding customization
-// to retry S3 InternalError code.
+// ShouldRetry overrides SDK's built in DefaultRetryer, adding custom retry
+// logics that are not included in the SDK.
 func (c *customRetryer) ShouldRetry(req *request.Request) bool {
 	if errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") {
 		return true

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -707,6 +707,7 @@ func TestS3listObjectsV2(t *testing.T) {
 }
 
 func TestSessionCreateAndCachingWithDifferentBuckets(t *testing.T) {
+	log.Init("error", false)
 	testcases := []struct {
 		bucket         string
 		alreadyCreated bool // sessions should not be created again if they already have been created before

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -762,8 +762,7 @@ func TestSessionAutoRegion(t *testing.T) {
 	unitSession := func() *session.Session {
 		return session.Must(session.NewSession(&aws.Config{
 			Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
-			// Region:      aws.String("mock-region"),
-			SleepDelay: func(time.Duration) {},
+			SleepDelay:  func(time.Duration) {},
 		}))
 	}
 

--- a/storage/url/url.go
+++ b/storage/url/url.go
@@ -260,7 +260,7 @@ func (u *URL) SetRelative(base string) {
 	u.relativePath, _ = filepath.Rel(dir, u.Absolute())
 }
 
-// Match checks if given key matches with the object.
+// Match reports whether if given key matches with the object.
 func (u *URL) Match(key string) bool {
 	if !u.filterRegex.MatchString(key) {
 		return false
@@ -288,7 +288,7 @@ func (u *URL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.String())
 }
 
-// HasGlob checks if a string contains any wildcard chars.
+// HasGlob reports whether if a string contains any wildcard chars.
 func (u *URL) HasGlob() bool {
 	return hasGlobCharacter(u.Path)
 }
@@ -343,7 +343,7 @@ func parseNonBatch(prefix string, key string) string {
 	return trimmedKey
 }
 
-// hasGlobCharacter checks if a string contains any wildcard chars.
+// hasGlobCharacter reports whether if a string contains any wildcard chars.
 func hasGlobCharacter(s string) bool {
 	return strings.ContainsAny(s, globCharacters)
 }


### PR DESCRIPTION
If GetBucketRegion request fails, inform the caller, delegate error
handling to command execution.

Updates #237
Fixes #251
Fixes #252