### PR TITLE
e2e: fix incorrect flag usage

### DIFF
--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -130,7 +130,7 @@ func TestCopySingleS3ObjectToLocalJSON(t *testing.T) {
 
 	putFile(t, s3client, bucket, filename, content)
 
-	cmd := s5cmd("-json", "cp", "s3://"+bucket+"/"+filename, ".")
+	cmd := s5cmd("--json", "cp", "s3://"+bucket+"/"+filename, ".")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -392,7 +392,7 @@ func TestCopyMultipleFlatS3ObjectsToLocalJSON(t *testing.T) {
 		putFile(t, s3client, bucket, filename, content)
 	}
 
-	cmd := s5cmd("-json", "cp", "--flatten", "s3://"+bucket+"/*", ".")
+	cmd := s5cmd("--json", "cp", "--flatten", "s3://"+bucket+"/*", ".")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -729,7 +729,7 @@ func TestCopySingleFileToS3JSON(t *testing.T) {
 
 	fpath := workdir.Join(filename)
 
-	cmd := s5cmd("-json", "cp", fpath, "s3://"+bucket+"/")
+	cmd := s5cmd("--json", "cp", fpath, "s3://"+bucket+"/")
 	result := icmd.RunCmd(cmd)
 
 	jsonText := `
@@ -1461,7 +1461,7 @@ func TestCopySingleS3ObjectToS3JSON(t *testing.T) {
 	src := fmt.Sprintf("s3://%v/%v", bucket, filename)
 	dst := fmt.Sprintf("s3://%v/%v", bucket, dstfilename)
 
-	cmd := s5cmd("-json", "cp", src, dst)
+	cmd := s5cmd("--json", "cp", src, dst)
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -1813,7 +1813,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 	src := fmt.Sprintf("s3://%v/*", bucket)
 	dst := fmt.Sprintf("s3://%v/dst/", bucket)
 
-	cmd := s5cmd("-json", "cp", src, dst)
+	cmd := s5cmd("--json", "cp", src, dst)
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -1955,7 +1955,7 @@ func TestCopyS3ToLocalWithSameFilenameWithNoClobber(t *testing.T) {
 	// upload a modified version of the file
 	putFile(t, s3client, bucket, filename, content+"\n")
 
-	cmd := s5cmd("-log=debug", "cp", "-n", "s3://"+bucket+"/"+filename, ".")
+	cmd := s5cmd("--log=debug", "cp", "-n", "s3://"+bucket+"/"+filename, ".")
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	result.Assert(t, icmd.Success)
@@ -2078,7 +2078,7 @@ func TestCopyS3ToLocalWithSameFilenameDontOverrideIfS3ObjectIsOlder(t *testing.T
 	workdir := fs.NewDir(t, t.Name(), fs.WithFile(filename, content, timestamp))
 	defer workdir.Remove()
 
-	cmd := s5cmd("-log=debug", "cp", "-n", "-u", "s3://"+bucket+"/"+filename, ".")
+	cmd := s5cmd("--log=debug", "cp", "-n", "-u", "s3://"+bucket+"/"+filename, ".")
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	// '-n' prevents overriding the file, but '-s' overrides '-n' if the file
@@ -2214,7 +2214,7 @@ func TestCopyLocalFileToS3WithSameFilenameWithNoClobber(t *testing.T) {
 	workdir := fs.NewDir(t, t.Name(), fs.WithFile(filename, newContent))
 	defer workdir.Remove()
 
-	cmd := s5cmd("-log=debug", "cp", "-n", filename, "s3://"+bucket)
+	cmd := s5cmd("--log=debug", "cp", "-n", filename, "s3://"+bucket)
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	result.Assert(t, icmd.Success)
@@ -2386,7 +2386,7 @@ func TestCopyLocalFileToS3WithSameFilenameDontOverrideIfS3ObjectIsOlder(t *testi
 	workdir := fs.NewDir(t, t.Name(), fs.WithFile(filename, expectedContent, timestamp))
 	defer workdir.Remove()
 
-	cmd := s5cmd("-log=debug", "cp", "-n", "-u", filename, "s3://"+bucket)
+	cmd := s5cmd("--log=debug", "cp", "-n", "-u", filename, "s3://"+bucket)
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	// '-n' prevents overriding the file, but '-u' overrides '-n' if the file

--- a/e2e/du_test.go
+++ b/e2e/du_test.go
@@ -45,7 +45,7 @@ func TestDiskUsageSingleS3ObjectJSON(t *testing.T) {
 	putFile(t, s3client, bucket, "testfile1.txt", "this is a file content")
 	putFile(t, s3client, bucket, "testfile2.txt", "this is also a file content")
 
-	cmd := s5cmd("-json", "du", "s3://"+bucket+"/testfile1.txt")
+	cmd := s5cmd("--json", "du", "s3://"+bucket+"/testfile1.txt")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)

--- a/e2e/ls_test.go
+++ b/e2e/ls_test.go
@@ -49,7 +49,7 @@ func TestListBucketsJSON(t *testing.T) {
 	createBucket(t, s3client, bucketPrefix+"-4")
 	createBucket(t, s3client, bucketPrefix+"-3")
 
-	cmd := s5cmd("-json", "ls")
+	cmd := s5cmd("--json", "ls")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -103,7 +103,7 @@ func TestListSingleS3ObjectJSON(t *testing.T) {
 	putFile(t, s3client, bucket, "testfile1.txt", "this is a file content")
 	putFile(t, s3client, bucket, "testfile2.txt", "this is also a file content")
 
-	cmd := s5cmd("-json", "ls", "s3://"+bucket+"/testfile1.txt")
+	cmd := s5cmd("--json", "ls", "s3://"+bucket+"/testfile1.txt")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)

--- a/e2e/rm_test.go
+++ b/e2e/rm_test.go
@@ -61,7 +61,7 @@ func TestRemoveSingleS3ObjectJSON(t *testing.T) {
 
 	putFile(t, s3client, bucket, filename, content)
 
-	cmd := s5cmd("-json", "rm", "s3://"+bucket+"/"+filename)
+	cmd := s5cmd("--json", "rm", "s3://"+bucket+"/"+filename)
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -148,7 +148,7 @@ func TestRemoveMultipleS3ObjectsJSON(t *testing.T) {
 		putFile(t, s3client, bucket, filename, content)
 	}
 
-	cmd := s5cmd("-json", "rm", "s3://"+bucket+"/*")
+	cmd := s5cmd("--json", "rm", "s3://"+bucket+"/*")
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)


### PR DESCRIPTION
Not a critical change. Single dash is still valid for the CLI parser.