### PR TITLE
storage/s3: propagate retryable errors from sdk to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ server-side throttling errors. Non-retriable errors, such as `invalid
 credentials`, `authorization errors` etc, will not be retried. By default,
 `s5cmd` will retry 10 times for up to a minute. Number of retries are adjustable
 via `--retry-count` flag.
+ℹ️ Enable debug level logging for displaying retryable errors.
 
 ## Using wildcards
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ server-side throttling errors. Non-retriable errors, such as `invalid
 credentials`, `authorization errors` etc, will not be retried. By default,
 `s5cmd` will retry 10 times for up to a minute. Number of retries are adjustable
 via `--retry-count` flag.
+
 ℹ️ Enable debug level logging for displaying retryable errors.
 
 ## Using wildcards

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -744,8 +744,8 @@ func (c *customRetryer) ShouldRetry(req *request.Request) bool {
 
 	if shouldRetry && req.Error != nil {
 		err := fmt.Errorf("retryable error: %v", req.Error)
-		msg := log.ErrorMessage{Err: err.Error()}
-		log.Error(msg)
+		msg := log.DebugMessage{Err: err.Error()}
+		log.Debug(msg)
 	}
 
 	return shouldRetry

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -737,11 +737,18 @@ func newCustomRetryer(maxRetries int) *customRetryer {
 // ShouldRetry overrides SDK's built in DefaultRetryer, adding custom retry
 // logics that are not included in the SDK.
 func (c *customRetryer) ShouldRetry(req *request.Request) bool {
-	if errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") {
-		return true
+	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed")
+	if !shouldRetry {
+		shouldRetry = c.DefaultRetryer.ShouldRetry(req)
 	}
 
-	return c.DefaultRetryer.ShouldRetry(req)
+	if shouldRetry && req.Error != nil {
+		err := fmt.Errorf("retryable error: %v", req.Error)
+		msg := log.ErrorMessage{Err: err.Error()}
+		log.Error(msg)
+	}
+
+	return shouldRetry
 }
 
 var insecureHTTPClient = &http.Client{

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -286,6 +286,8 @@ func TestS3ListContextCancelled(t *testing.T) {
 }
 
 func TestS3Retry(t *testing.T) {
+	log.Init("error", false)
+
 	testcases := []struct {
 		name string
 		err  error

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -286,7 +286,7 @@ func TestS3ListContextCancelled(t *testing.T) {
 }
 
 func TestS3Retry(t *testing.T) {
-	log.Init("error", false)
+	log.Init("debug", false)
 
 	testcases := []struct {
 		name string


### PR DESCRIPTION
I think it would be useful to inform the caller for retryable errors. If retryable errors are received during command execution, users should be able to get information about it. 