### PR TITLE
command/cp: fix minor printing issue if 'cp' command is called without arguments

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -758,5 +758,10 @@ func guessContentType(file *os.File) string {
 }
 
 func givenCommand(c *cli.Context) string {
-	return fmt.Sprintf("%v %v", c.Command.FullName(), strings.Join(c.Args().Slice(), " "))
+	cmd := c.Command.FullName()
+	if c.Args().Len() > 0 {
+		cmd = fmt.Sprintf("%v %v", cmd, strings.Join(c.Args().Slice(), " "))
+	}
+
+	return cmd
 }

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -22,7 +22,7 @@ func TestAppRetryCount(t *testing.T) {
 		{
 			name:             "retry_count_negative",
 			retry:            -1,
-			expectedError:    fmt.Errorf(`ERROR " ": retry count cannot be a negative value`),
+			expectedError:    fmt.Errorf(`ERROR retry count cannot be a negative value`),
 			expectedExitCode: 1,
 		},
 		{


### PR DESCRIPTION
#### before
```sh
$ s5cmd cp
ERROR "cp ": expected source and destination arguments
```

#### after
```sh
$ s5cmd cp
ERROR "cp": expected source and destination arguments
```