### PR TITLE
github/goreleaser: trigger just for tags with 'v' prefix

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,7 +2,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as build
+FROM golang:1.16-alpine as build
 COPY . /s5cmd/
 RUN apk add --no-cache git make && \
     cd /s5cmd/ && \


### PR DESCRIPTION
Also, use Go 1.16 for builds.