### PR TITLE
Treat "connection reset" errors as retryable.

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -737,7 +737,7 @@ func newCustomRetryer(maxRetries int) *customRetryer {
 // ShouldRetry overrides SDK's built in DefaultRetryer, adding custom retry
 // logics that are not included in the SDK.
 func (c *customRetryer) ShouldRetry(req *request.Request) bool {
-	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed")
+	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") || strings.Contains(req.Error.Error(), "connection reset")
 	if !shouldRetry {
 		shouldRetry = c.DefaultRetryer.ShouldRetry(req)
 	}


### PR DESCRIPTION
Per
https://github.com/aws/aws-sdk-go/pull/2926#issuecomment-553196888,
the upstream SDK doesn't retry connection reset errors on reads,
because at that point we can't tell if the server has already applied
the operation.

For S3 operations, I think pretty much all requests should be safely
idempotent, so I think we should retry these errors.

I saw some of my own long-running jobs fail this weekend due to
network weather and some dropped connections that s5cmd did not retry,
which I found very surprising.

Per
https://github.com/aws/aws-sdk-go/commit/c3d27102088451890a9ba5be0dc1f2e0425f0fc3,
the `strings.Contains` check does seem to be the best way to check for
this error.

This might fix #294, or there might be something deeper going on there.