### PR TITLE
goreleaser: rename github to tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ changelog:
       - Merge branch
 
 brews:
-  - github:
+  - tap:
       owner: peak
       name: s5cmd
     folder: Formula


### PR DESCRIPTION
Looks like the `github` field is renamed to `tap`. https://goreleaser.com/customization/homebrew/