### PR TITLE
Add steps for installation using MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ For macOS, a [homebrew](https://brew.sh) tap is provided:
     brew tap peak/s5cmd https://github.com/peak/s5cmd
     brew install s5cmd
 
+### MacPorts
+
+You can also install `s5cmd` from [MacPorts](https://ports.macports.org/port/s5cmd/summary) on macOS:
+
+    sudo port selfupdate
+    sudo port install s5cmd
+
+NOTE: MacPorts is not officially supported. The versions might be out of date compared to Homebrew.
+
 ### Build from source
 
 You can build `s5cmd` from source if you have [Go](https://golang.org/dl/) 1.14+


### PR DESCRIPTION
Hi! I'm a macOS user and I noticed that this tool is available on Homebrew but was missing from MacPorts. So I took the liberty of adding the package. This PR updates the README with installation steps. 

Relevant links: 
* MacPorts: https://www.macports.org/
* Installation Config: https://github.com/macports/macports-ports/blob/master/net/s5cmd/Portfile