### PR TITLE
fix lost region

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -717,7 +717,9 @@ func (sc *SessionCache) clear() {
 }
 
 func setSessionRegion(ctx context.Context, sess *session.Session, bucket string) error {
-	if aws.StringValue(sess.Config.Region) == "" {
+	if aws.StringValue(sess.Config.Region) != "" {
+		return nil
+	} else {
 		sess.Config.Region = aws.String(endpoints.UsEast1RegionID)
 	}
 


### PR DESCRIPTION
Hi this PR fixes lost region, Options opts.region are used only internally for cp src dst region, there is no cmd flag for region,  so setSessionRegion is called for command like ls, run etc. If the region is set via env or config file is never used, func always fallback to aws-sdk s3manager.GetBucketRegion, but aws sdk will not recognize non aws regions like nl-ams (scaleway).
