### PR TITLE
add cache-control and expires options

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -134,6 +134,14 @@ var copyCommandFlags = []cli.Flag{
 		Name:  "acl",
 		Usage: "set acl for target: defines granted accesses and their types on different accounts/groups",
 	},
+	&cli.StringFlag{
+		Name:  "cache-control",
+		Usage: "set cache control for target: defines cache control header for object",
+	},
+	&cli.StringFlag{
+		Name:  "expires",
+		Usage: "set expires for target (uses RFC3339 format): defines expires header for object",
+	},
 	&cli.BoolFlag{
 		Name:  "force-glacier-transfer",
 		Usage: "force transfer of GLACIER objects whether they are restored or not",
@@ -183,6 +191,8 @@ var copyCommand = &cli.Command{
 			encryptionKeyID:      c.String("sse-kms-key-id"),
 			acl:                  c.String("acl"),
 			forceGlacierTransfer: c.Bool("force-glacier-transfer"),
+			cacheControl:         c.String("cache-control"),
+			expires:              c.String("expires"),
 			// region settings
 			srcRegion: c.String("source-region"),
 			dstRegion: c.String("destination-region"),
@@ -212,6 +222,9 @@ type Copy struct {
 	encryptionKeyID      string
 	acl                  string
 	forceGlacierTransfer bool
+	cacheControl         string
+	expires              string
+
 
 	// region settings
 	srcRegion string
@@ -472,7 +485,9 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) er
 		SetStorageClass(string(c.storageClass)).
 		SetSSE(c.encryptionMethod).
 		SetSSEKeyID(c.encryptionKeyID).
-		SetACL(c.acl)
+		SetACL(c.acl).
+		SetCacheControl(c.cacheControl).
+		SetExpires(c.expires)
 
 	err = dstClient.Put(ctx, file, dsturl, metadata, c.concurrency, c.partSize)
 	if err != nil {
@@ -518,7 +533,9 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL) error {
 		SetStorageClass(string(c.storageClass)).
 		SetSSE(c.encryptionMethod).
 		SetSSEKeyID(c.encryptionKeyID).
-		SetACL(c.acl)
+		SetACL(c.acl).
+		SetCacheControl(c.cacheControl).
+		SetExpires(c.expires)
 
 	err = c.shouldOverride(ctx, srcurl, dsturl)
 	if err != nil {

--- a/command/cp.go
+++ b/command/cp.go
@@ -76,9 +76,18 @@ Examples:
 
 	13. Perform KMS-SSE of the object(s) at the destination using customer managed Customer Master Key (CMK) key id
 		> s5cmd {{.HelpName}} --sse aws:kms --sse-kms-key-id <your-kms-key-id> s3://bucket/object s3://target-bucket/prefix/object
-	
+
 	14. Force transfer of GLACIER objects with a prefix whether they are restored or not
 		> s5cmd {{.HelpName}} --force-glacier-transfer s3://bucket/prefix/* target-directory/
+
+	15. Upload a file to S3 bucket with public read s3 acl
+		> s5cmd {{.HelpName}} --acl "public-read" myfile.gz s3://bucket/
+
+	16. Upload a file to S3 bucket with expires header
+		> s5cmd {{.HelpName}} --expires "2024-10-01T20:30:00Z" myfile.gz s3://bucket/
+
+	17. Upload a file to S3 bucket with cache-control header
+		> s5cmd {{.HelpName}} --cache-control "public, max-age=345600" myfile.gz s3://bucket/
 `
 
 var copyCommandFlags = []cli.Flag{
@@ -132,15 +141,15 @@ var copyCommandFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "acl",
-		Usage: "set acl for target: defines granted accesses and their types on different accounts/groups",
+		Usage: "set acl for target: defines granted accesses and their types on different accounts/groups, e.g. cp --acl 'public-read'",
 	},
 	&cli.StringFlag{
 		Name:  "cache-control",
-		Usage: "set cache control for target: defines cache control header for object",
+		Usage: "set cache control for target: defines cache control header for object, e.g. cp --cache-control 'public, max-age=345600'",
 	},
 	&cli.StringFlag{
 		Name:  "expires",
-		Usage: "set expires for target (uses RFC3339 format): defines expires header for object",
+		Usage: "set expires for target (uses RFC3339 format): defines expires header for object, e.g. cp  --expires '2024-10-01T20:30:00Z'",
 	},
 	&cli.BoolFlag{
 		Name:  "force-glacier-transfer",

--- a/command/mv.go
+++ b/command/mv.go
@@ -61,6 +61,9 @@ var moveCommand = &cli.Command{
 			encryptionMethod: c.String("sse"),
 			encryptionKeyID:  c.String("sse-kms-key-id"),
 			acl:              c.String("acl"),
+			cacheControl:     c.String("cache-control"),
+			expires:          c.String("expires"),
+
 
 			storageOpts: NewStorageOpts(c),
 		}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -514,11 +514,10 @@ func (s *S3) Put(
 	expires := metadata.Expires()
 	if expires != "" {
 		t, err := time.Parse(time.RFC3339, expires)
-		if err == nil {
-			input.Expires = aws.Time(t)
-		} else {
+		if err != nil {
 			return err
 		}
+		input.Expires = aws.Time(t)
 	}
 
 	sseEncryption := metadata.SSE()

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -344,6 +344,22 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 		input.ACL = aws.String(acl)
 	}
 
+	cacheControl := metadata.CacheControl()
+	if cacheControl != "" {
+		input.CacheControl = aws.String(cacheControl)
+	}
+
+	expires := metadata.Expires()
+	if expires != "" {
+		t, err := time.Parse(time.RFC3339, expires)
+		if err == nil {
+			input.Expires = aws.Time(t)
+		} else {
+			msg := log.DebugMessage{Err: err.Error()}
+			log.Debug(msg)
+		}
+	}
+
 	_, err := s.api.CopyObject(input)
 	return err
 }
@@ -416,6 +432,22 @@ func (s *S3) Put(
 	acl := metadata.ACL()
 	if acl != "" {
 		input.ACL = aws.String(acl)
+	}
+
+	cacheControl := metadata.CacheControl()
+	if cacheControl != "" {
+		input.CacheControl = aws.String(cacheControl)
+	}
+
+	expires := metadata.Expires()
+	if expires != "" {
+		t, err := time.Parse(time.RFC3339, expires)
+		if err == nil {
+			input.Expires = aws.Time(t)
+		} else {
+			msg := log.DebugMessage{Err: err.Error()}
+			log.Debug(msg)
+		}
 	}
 
 	sseEncryption := metadata.SSE()

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -353,11 +353,10 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 	expires := metadata.Expires()
 	if expires != "" {
 		t, err := time.Parse(time.RFC3339, expires)
-		if err == nil {
-			input.Expires = aws.Time(t)
-		} else {
+		if err != nil {
 			return err
 		}
+		input.Expires = aws.Time(t)
 	}
 
 	_, err := s.api.CopyObject(input)

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -356,8 +356,7 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 		if err == nil {
 			input.Expires = aws.Time(t)
 		} else {
-			msg := log.DebugMessage{Err: err.Error()}
-			log.Debug(msg)
+			return err
 		}
 	}
 
@@ -519,8 +518,7 @@ func (s *S3) Put(
 		if err == nil {
 			input.Expires = aws.Time(t)
 		} else {
-			msg := log.DebugMessage{Err: err.Error()}
-			log.Debug(msg)
+			return err
 		}
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -208,6 +208,24 @@ func (m Metadata) SetACL(acl string) Metadata {
 	return m
 }
 
+func (m Metadata) CacheControl() string {
+	return m["CacheControl"]
+}
+
+func (m Metadata) SetCacheControl(cacheControl string) Metadata {
+	m["CacheControl"] = cacheControl
+	return m
+}
+
+func (m Metadata) Expires() string {
+	return m["Expires"]
+}
+
+func (m Metadata) SetExpires(expires string) Metadata {
+	m["Expires"] = expires
+	return m
+}
+
 func (m Metadata) StorageClass() string {
 	return m["StorageClass"]
 }


### PR DESCRIPTION
Hello, this PR add support for setting cache-control and expires header to s3 object, same as aws cli
```bash
s5cmd cp --acl "public-read" --expires "2024-10-01T20:30:00Z" --cache-control "public, max-age=345600, s-maxage=345600" foobar
  s3://example-bucket/foobar
```