### PR TITLE
makefile: fix check-fmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ vet:
 .PHONY: check-fmt
 check-fmt:
 	@if go fmt -mod=vendor ./...; then\
-        echo "Go code is not formatted";\
+		echo "Go code is not formatted";\
 		exit 1;\
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ vet:
 
 .PHONY: check-fmt
 check-fmt:
-	@if go fmt -mod=vendor ./...; then\
+	@if [ $$(go fmt -mod=vendor ./...) ]; then\
 		echo "Go code is not formatted";\
 		exit 1;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ vet:
 
 .PHONY: check-fmt
 check-fmt:
-	@sh -c 'if [ -n "$(go fmt -mod=vendor ./...)" ]; then echo "Go code is not formatted"; exit 1; fi'
+	@if go fmt -mod=vendor ./...; then\
+        echo "Go code is not formatted";\
+		exit 1;\
+    fi
 
 .PHONY: mock
 mock:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ check-fmt:
 	@if go fmt -mod=vendor ./...; then\
         echo "Go code is not formatted";\
 		exit 1;\
-    fi
+	fi
 
 .PHONY: mock
 mock:

--- a/command/mv.go
+++ b/command/mv.go
@@ -64,7 +64,6 @@ var moveCommand = &cli.Command{
 			cacheControl:     c.String("cache-control"),
 			expires:          c.String("expires"),
 
-
 			storageOpts: NewStorageOpts(c),
 		}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -48,13 +48,13 @@ func NewLocalClient(opts Options) *Filesystem {
 
 func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, error) {
 	newOpts := Options{
-		MaxRetries:  opts.MaxRetries,
-		Endpoint:    opts.Endpoint,
-		NoVerifySSL: opts.NoVerifySSL,
-		DryRun:      opts.DryRun,
+		MaxRetries:    opts.MaxRetries,
+		Endpoint:      opts.Endpoint,
+		NoVerifySSL:   opts.NoVerifySSL,
+		DryRun:        opts.DryRun,
 		NoSignRequest: opts.NoSignRequest,
-		bucket:      url.Bucket,
-		region:      opts.region,
+		bucket:        url.Bucket,
+		region:        opts.region,
 	}
 	return newS3Storage(ctx, newOpts)
 }
@@ -68,13 +68,13 @@ func NewClient(ctx context.Context, url *url.URL, opts Options) (Storage, error)
 
 // Options stores configuration for storage.
 type Options struct {
-	MaxRetries  int
-	Endpoint    string
-	NoVerifySSL bool
-	DryRun      bool
+	MaxRetries    int
+	Endpoint      string
+	NoVerifySSL   bool
+	DryRun        bool
 	NoSignRequest bool
-	bucket      string
-	region      string
+	bucket        string
+	region        string
 }
 
 func (o *Options) SetRegion(region string) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -14,10 +14,10 @@ import (
 
 var (
 	// ErrGivenObjectNotFound indicates a specified object is not found.
-	ErrGivenObjectNotFound = fmt.Errorf("given object not found")
+ErrGivenObjectNotFound = fmt.Errorf("given object not found")
 
 	// ErrNoObjectFound indicates there are no objects found from a given directory.
-	ErrNoObjectFound = fmt.Errorf("no object found")
+			ErrNoObjectFound = fmt.Errorf("no object found")
 )
 
 // Storage is an interface for storage operations that is common

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -14,10 +14,10 @@ import (
 
 var (
 	// ErrGivenObjectNotFound indicates a specified object is not found.
-ErrGivenObjectNotFound = fmt.Errorf("given object not found")
+	ErrGivenObjectNotFound = fmt.Errorf("given object not found")
 
 	// ErrNoObjectFound indicates there are no objects found from a given directory.
-			ErrNoObjectFound = fmt.Errorf("no object found")
+	ErrNoObjectFound = fmt.Errorf("no object found")
 )
 
 // Storage is an interface for storage operations that is common


### PR DESCRIPTION
* CI does not fail if go code is not formatted since `check-fmt` target in makefile is not working properly