### PR TITLE
command: append object error to multierror to return non-zero exit code error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## not released yet
+
+#### Features
+
+
+#### Improvements
+
+
+#### Bugfixes
+- Fixed a bug where errors did not result a non-zero exit code. ([#304](https://github.com/peak/s5cmd/issues/304))
+
 ## v1.3.0 - 1 Jul 2021
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,21 @@
 
 #### Features
 
+- Added new `--raw` flag to `cp` and `rm` commands. It disables the wildcard operations. It is useful when only an object contains glob characters wants to be downloaded. ([#235](https://github.com/peak/s5cmd/issues/235))
+- Added new `--cache-control` and `--expires` flags to `cp` and `rm` commands. It adds support for setting cache control and expires header to S3 objects. ([#318](https://github.com/peak/s5cmd/pull/318)) [@tombokombo](https://github.com/tombokombo)
+- Added new `select` command. It allows to select JSON records from objects using SQL expressions. ([#299](https://github.com/peak/s5cmd/issues/299)) [@skeggse](https://github.com/skeggse)
+- Added new `--force-glacier-transfer` flag to `cp` command. This flag forces transfer of GLACIER objects whether they are restored or not. ([#206](https://github.com/peak/s5cmd/issues/206))
+- Added new `--source-region` and `destination-region` flags to `cp` command. It allows overriding bucket region. ([#262](https://github.com/peak/s5cmd/issues/262)) [@kemege](https://github.com/kemege)
+- Added new `rb` command which allows users to remove buckets from command line. ([#303](https://github.com/peak/s5cmd/issues/303)).
 
 #### Improvements
 
+- Added new installation option MacPorts. ([#311](https://github.com/peak/s5cmd/pull/311)) [@manojkarthick](https://github.com/manojkarthick)
 
 #### Bugfixes
+
 - Fixed a bug where errors did not result a non-zero exit code. ([#304](https://github.com/peak/s5cmd/issues/304))
+- Change the order of precedence in URL expansion in file system. Glob (*) expansion have precedence over directory expansion. ([#322](https://github.com/peak/s5cmd/pull/322))
 
 ## v1.3.0 - 1 Jul 2021
 

--- a/command/cp.go
+++ b/command/cp.go
@@ -292,7 +292,7 @@ func (c Copy) Run(ctx context.Context) error {
 
 	// create two different error objects instead of single object to avoid the
 	// data race for merror object, since there is a goroutine running,
-	// there might be a data rice for a single error object.
+	// there might be a data race for a single error object.
 	var (
 		merrorWaiter  error // for the errors from waiter
 		merrorObjects error // for the errors from object channel

--- a/command/cp.go
+++ b/command/cp.go
@@ -321,6 +321,7 @@ func (c Copy) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
+			merror = multierror.Append(merror, err)
 			printError(c.fullCommand, c.op, err)
 			continue
 		}

--- a/command/cp.go
+++ b/command/cp.go
@@ -328,6 +328,7 @@ func (c Copy) Run(ctx context.Context) error {
 
 		if object.StorageClass.IsGlacier() && !c.forceGlacierTransfer {
 			err := fmt.Errorf("object '%v' is on Glacier storage", object)
+			merror = multierror.Append(merror, err)
 			printError(c.fullCommand, c.op, err)
 			continue
 		}

--- a/command/rm.go
+++ b/command/rm.go
@@ -96,6 +96,7 @@ func (d Delete) Run(ctx context.Context) error {
 	}
 
 	objch := expandSources(ctx, client, false, srcurls...)
+	var merror error
 
 	// do object->url transformation
 	urlch := make(chan *url.URL)
@@ -108,6 +109,7 @@ func (d Delete) Run(ctx context.Context) error {
 			}
 
 			if err := object.Err; err != nil {
+				merror = multierror.Append(merror, err)
 				printError(d.fullCommand, d.op, err)
 				continue
 			}
@@ -117,7 +119,6 @@ func (d Delete) Run(ctx context.Context) error {
 
 	resultch := client.MultiDelete(ctx, urlch)
 
-	var merror error
 	for obj := range resultch {
 		if err := obj.Err; err != nil {
 			if errorpkg.IsCancelation(obj.Err) {

--- a/command/rm.go
+++ b/command/rm.go
@@ -99,7 +99,7 @@ func (d Delete) Run(ctx context.Context) error {
 
 	// create two different error objects instead of single object to avoid the
 	// data race for merror object, since there is a goroutine running,
-	// there might be a data rice for a single error object.
+	// there might be a data race for a single error object.
 	var (
 		merrorObjects error
 		merrorResult  error

--- a/command/select.go
+++ b/command/select.go
@@ -118,8 +118,8 @@ func (s Select) Run(ctx context.Context) error {
 	// data race for merror object, since there is a goroutine running,
 	// there might be a data race for a single error object.
 	var (
-		merrorWaiter error
-		merrorObject error
+		merrorWaiter  error
+		merrorObjects error
 	)
 
 	waiter := parallel.NewWaiter()
@@ -162,14 +162,14 @@ func (s Select) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
-			merrorObject = multierror.Append(merrorObject, err)
+			merrorObjects = multierror.Append(merrorObjects, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}
 
 		if object.StorageClass.IsGlacier() {
 			err := fmt.Errorf("object '%v' is on Glacier storage", object)
-			merrorObject = multierror.Append(merrorObject, err)
+			merrorObjects = multierror.Append(merrorObjects, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}
@@ -182,7 +182,7 @@ func (s Select) Run(ctx context.Context) error {
 	<-errDoneCh
 	<-writeDoneCh
 
-	return multierror.Append(merrorWaiter, merrorObject).ErrorOrNil()
+	return multierror.Append(merrorWaiter, merrorObjects).ErrorOrNil()
 }
 
 func (s Select) prepareTask(ctx context.Context, client *storage.S3, url *url.URL, resultCh chan<- json.RawMessage) func() error {

--- a/command/select.go
+++ b/command/select.go
@@ -163,6 +163,7 @@ func (s Select) Run(ctx context.Context) error {
 
 		if object.StorageClass.IsGlacier() {
 			err := fmt.Errorf("object '%v' is on Glacier storage", object)
+			merror = multierror.Append(merror, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}

--- a/command/select.go
+++ b/command/select.go
@@ -156,6 +156,7 @@ func (s Select) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
+			merror = multierror.Append(merror, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}

--- a/command/select.go
+++ b/command/select.go
@@ -116,7 +116,7 @@ func (s Select) Run(ctx context.Context) error {
 
 	// create two different error objects instead of single object to avoid the
 	// data race for merror object, since there is a goroutine running,
-	// there might be a data rice for a single error object.
+	// there might be a data race for a single error object.
 	var (
 		merrorWaiter error
 		merrorObject error

--- a/command/select.go
+++ b/command/select.go
@@ -114,7 +114,13 @@ func (s Select) Run(ctx context.Context) error {
 		return err
 	}
 
-	var merror error
+	// create two different error objects instead of single object to avoid the
+	// data race for merror object, since there is a goroutine running,
+	// there might be a data rice for a single error object.
+	var (
+		merrorWaiter error
+		merrorObject error
+	)
 
 	waiter := parallel.NewWaiter()
 	errDoneCh := make(chan bool)
@@ -125,7 +131,7 @@ func (s Select) Run(ctx context.Context) error {
 		defer close(errDoneCh)
 		for err := range waiter.Err() {
 			printError(s.fullCommand, s.op, err)
-			merror = multierror.Append(merror, err)
+			merrorWaiter = multierror.Append(merrorWaiter, err)
 		}
 	}()
 
@@ -156,14 +162,14 @@ func (s Select) Run(ctx context.Context) error {
 		}
 
 		if err := object.Err; err != nil {
-			merror = multierror.Append(merror, err)
+			merrorObject = multierror.Append(merrorObject, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}
 
 		if object.StorageClass.IsGlacier() {
 			err := fmt.Errorf("object '%v' is on Glacier storage", object)
-			merror = multierror.Append(merror, err)
+			merrorObject = multierror.Append(merrorObject, err)
 			printError(s.fullCommand, s.op, err)
 			continue
 		}
@@ -176,7 +182,7 @@ func (s Select) Run(ctx context.Context) error {
 	<-errDoneCh
 	<-writeDoneCh
 
-	return merror
+	return multierror.Append(merrorWaiter, merrorObject).ErrorOrNil()
 }
 
 func (s Select) prepareTask(ctx context.Context, client *storage.S3, url *url.URL, resultCh chan<- json.RawMessage) func() error {

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -3348,42 +3348,6 @@ func TestCopyRawModeAllowDestinationWithoutPrefix(t *testing.T) {
 	}
 }
 
-func TestCopyFalseCredentialsExitCode1(t *testing.T) {
-	t.Parallel()
-
-	const bucket = "bucket"
-
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
-
-	createBucket(t, s3client, bucket)
-
-	folderLayout := []fs.PathOp{
-		fs.WithFile("testfile.txt", "this is a test file 1"),
-		fs.WithFile("readme.md", "this is a readme file"),
-		fs.WithDir(
-			"a",
-			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
-		),
-		fs.WithDir(
-			"b",
-			fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
-		),
-	}
-
-	workdir := fs.NewDir(t, "somedir", folderLayout...)
-	defer workdir.Remove()
-
-	src := fmt.Sprintf("%v/testfile.txt", workdir.Path())
-	src = filepath.ToSlash(src)
-	dst := fmt.Sprintf("s3://%s/", bucket)
-
-	cmd := s5cmd(`AWS_ACCESS_KEY_ID=""`, `AWS_SECRET_ACCESS_KEY=""`, "cp", src, dst)
-	result := icmd.RunCmd(cmd)
-
-	result.Assert(t, icmd.Expected{ExitCode: 1})
-}
-
 func TestCopyNonExistEndpointURL(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -3348,25 +3348,16 @@ func TestCopyRawModeAllowDestinationWithoutPrefix(t *testing.T) {
 	}
 }
 
-func TestCopyNonExistEndpointURL(t *testing.T) {
+func TestCopyExpectExitCode1OnUnreachableHost(t *testing.T) {
 	t.Parallel()
 
 	const bucket = "bucket"
 
-	_, s5cmd, cleanup := setup(t, withEndpointURL("nonExistEndpointURL"))
+	_, s5cmd, cleanup := setup(t, withEndpointURL("nonExistingEndpointURL"))
 	defer cleanup()
 
 	folderLayout := []fs.PathOp{
 		fs.WithFile("testfile.txt", "this is a test file 1"),
-		fs.WithFile("readme.md", "this is a readme file"),
-		fs.WithDir(
-			"a",
-			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
-		),
-		fs.WithDir(
-			"b",
-			fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
-		),
 	}
 
 	workdir := fs.NewDir(t, "somedir", folderLayout...)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -3249,6 +3249,7 @@ func TestCopyMultipleS3ObjectsToS3WithRawMode(t *testing.T) {
 		"file*.txt": "this is a test file 1",
 	}
 
+	// assert s3 objects in destination.
 	for filename, content := range expectedFiles {
 		assert.Assert(t, ensureS3Object(s3client, destBucket, filename, content))
 	}

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -158,19 +158,16 @@ func s5cmd(workdir, endpoint string) func(args ...string) icmd.Cmd {
 
 		cmd := icmd.Command(s5cmdPath, args...)
 		env := os.Environ()
-		if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-			env = append(
-				env,
-				[]string{
-					fmt.Sprintf("AWS_ACCESS_KEY_ID=%v", defaultAccessKeyID),
-					fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%v", defaultSecretAccessKey),
-				}...,
-			)
-		}
+		env = append(
+			env,
+			[]string{
+				fmt.Sprintf("AWS_ACCESS_KEY_ID=%v", defaultAccessKeyID),
+				fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%v", defaultSecretAccessKey),
+			}...,
+		)
 		cmd.Env = env
 		cmd.Dir = workdir
 
-		// fmt.Printf("environment: %v\n", os.Environ())
 		return cmd
 	}
 }

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -149,15 +149,19 @@ func s5cmd(workdir, endpoint string) func(args ...string) icmd.Cmd {
 
 		cmd := icmd.Command(s5cmdPath, args...)
 		env := os.Environ()
-		env = append(
-			env,
-			[]string{
-				fmt.Sprintf("AWS_ACCESS_KEY_ID=%v", defaultAccessKeyID),
-				fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%v", defaultSecretAccessKey),
-			}...,
-		)
+		if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+			env = append(
+				env,
+				[]string{
+					fmt.Sprintf("AWS_ACCESS_KEY_ID=%v", defaultAccessKeyID),
+					fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%v", defaultSecretAccessKey),
+				}...,
+			)
+		}
 		cmd.Env = env
 		cmd.Dir = workdir
+
+		// fmt.Printf("environment: %v\n", os.Environ())
 		return cmd
 	}
 }


### PR DESCRIPTION
* Creating two error objects instead of one, is to avoid data race. Since there is a goroutine running which tries to write `merror` object, there might be a data race for `merror` object in `cp`, `rm` and `select` commands. We can create 1 error object for the goroutine and 1 for the main routine, and append them at the end of the execution. 

Tested #304 's first case, it returns exit code 1. 

Resolves #304 