### PR TITLE
command/expand: fix data race for concurrent writes 

### DIFF
--- a/atomic/bool.go
+++ b/atomic/bool.go
@@ -1,0 +1,25 @@
+package atomic
+
+import "sync/atomic"
+
+// Bool is an atomic Boolean.
+type Bool int32
+
+// Set sets the Boolean to value.
+func (ab *Bool) Set(value bool) {
+	var i int32 = 0
+	if value {
+		i = 1
+	}
+
+	atomic.StoreInt32((*int32)(ab), int32(i))
+}
+
+// Get gets the Boolean value.
+func (ab *Bool) Get() bool {
+	if atomic.LoadInt32((*int32)(ab)) != 0 {
+		return true
+	}
+
+	return false
+}

--- a/atomic/bool.go
+++ b/atomic/bool.go
@@ -17,9 +17,5 @@ func (b *Bool) Set(value bool) {
 
 // Get gets the Boolean value.
 func (b *Bool) Get() bool {
-	if atomic.LoadInt32((*int32)(b)) != 0 {
-		return true
-	}
-
-	return false
+	return atomic.LoadInt32((*int32)(b)) != 0
 }

--- a/atomic/bool.go
+++ b/atomic/bool.go
@@ -6,18 +6,18 @@ import "sync/atomic"
 type Bool int32
 
 // Set sets the Boolean to value.
-func (ab *Bool) Set(value bool) {
+func (b *Bool) Set(value bool) {
 	var i int32 = 0
 	if value {
 		i = 1
 	}
 
-	atomic.StoreInt32((*int32)(ab), int32(i))
+	atomic.StoreInt32((*int32)(b), int32(i))
 }
 
 // Get gets the Boolean value.
-func (ab *Bool) Get() bool {
-	if atomic.LoadInt32((*int32)(ab)) != 0 {
+func (b *Bool) Get() bool {
+	if atomic.LoadInt32((*int32)(b)) != 0 {
 		return true
 	}
 

--- a/atomic/bool_test.go
+++ b/atomic/bool_test.go
@@ -1,0 +1,32 @@
+package atomic
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRace(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+	var atomicBool Bool
+	repeat := 10000
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < repeat; i++ {
+			atomicBool.Set(true)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < repeat; i++ {
+			_ = atomicBool.Get()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/command/expand.go
+++ b/command/expand.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/peak/s5cmd/atomic"
 	"github.com/peak/s5cmd/storage"
 	"github.com/peak/s5cmd/storage/url"
 )
@@ -58,7 +59,7 @@ func expandSources(
 		defer close(ch)
 
 		var wg sync.WaitGroup
-		var objFound bool
+		var objFound atomic.Bool
 
 		for _, origSrc := range srcurls {
 			wg.Add(1)
@@ -76,13 +77,13 @@ func expandSources(
 						continue
 					}
 					ch <- object
-					objFound = true
+					objFound.Set(true)
 				}
 			}(origSrc)
 		}
 
 		wg.Wait()
-		if !objFound {
+		if !objFound.Get() {
 			ch <- &storage.Object{Err: storage.ErrNoObjectFound}
 		}
 	}()


### PR DESCRIPTION
* Concurrent write to objFound bool is not thread-safe. Use atomic boolean to avoid data race.

When I run TestExpandSources with the race detector, it shows data race warnings.

`go test -race -mod=vendor -count=1 -run="TestExpandSources" ./...`

```
WARNING: DATA RACE
Write at 0x00c0000b673c by goroutine 30:
  github.com/peak/s5cmd/command.expandSources.func1.1()
      .../go/src/github.com/peak/s5cmd/command/expand.go:79 +0x1d5

Previous write at 0x00c0000b673c by goroutine 29:
  github.com/peak/s5cmd/command.expandSources.func1.1()
      .../go/src/github.com/peak/s5cmd/command/expand.go:79 +0x1d5

Goroutine 30 (running) created at:
  github.com/peak/s5cmd/command.expandSources.func1()
      .../go/src/github.com/peak/s5cmd/command/expand.go:65 +0x1e5

Goroutine 29 (finished) created at:
  github.com/peak/s5cmd/command.expandSources.func1()
      .../go/src/github.com/peak/s5cmd/command/expand.go:65 +0x1e5
```