### PR TITLE
command/run: fix concurrent writes to the flags list

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -120,7 +120,9 @@ var runCommand = &cli.Command{
 				}
 
 				ctx := cli.NewContext(app, flagset, c)
-				return cmd.Run(ctx)
+
+				safecmd := *cmd
+				return safecmd.Run(ctx)
 			}
 
 			pm.Run(fn, waiter)

--- a/command/run.go
+++ b/command/run.go
@@ -106,8 +106,8 @@ var runCommand = &cli.Command{
 			fn := func() error {
 				subcmd := fields[0]
 
-				cmd := app.Command(subcmd)
-				if cmd == nil {
+				cmdptr := app.Command(subcmd)
+				if cmdptr == nil {
 					err := fmt.Errorf("%q command (line: %v) not found", subcmd, lineno)
 					printError(givenCommand(c), c.Command.Name, err)
 					return nil
@@ -121,8 +121,10 @@ var runCommand = &cli.Command{
 
 				ctx := cli.NewContext(app, flagset, c)
 
-				safecmd := *cmd
-				return safecmd.Run(ctx)
+				// Use the dereferenced value to avoid urfave/cli package to
+				// mutate the command. Ref: https://github.com/peak/s5cmd/issues/301
+				cmd := *cmdptr
+				return cmd.Run(ctx)
 			}
 
 			pm.Run(fn, waiter)


### PR DESCRIPTION
The `run` command iterates over the commands list, where each item is a
pointer to the command. `urfave/cli` packages implicitly adds `-h` flag
to each command, which introduces data race because `s5cmd` executes
them in parallel.

Fixes #301