### PR TITLE
Support Environment S3_ENDPOINT_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,16 @@ object storage.
 
     s5cmd --endpoint-url https://storage.googleapis.com ls
 
-will return your GCS buckets.
+or an alternative with environment variable
+
+    S3_ENDPOINT_URL="https://storage.googleapis.com" s5cmd ls
+    
+    # or
+    
+    export S3_ENDPOINT_URL="https://storage.googleapis.com" 
+    s5cmd ls
+
+all variants will return your GCS buckets.
 
 `s5cmd` will use virtual-host style bucket resolving for S3, S3 transfer
 acceleration and GCS. If a custom endpoint is provided, it'll fallback to

--- a/command/app.go
+++ b/command/app.go
@@ -40,8 +40,8 @@ var app = &cli.App{
 			Usage:   "number of times that a request will be retried for failures",
 		},
 		&cli.StringFlag{
-			Name:  "endpoint-url",
-			Usage: "override default S3 host for custom services",
+			Name:    "endpoint-url",
+			Usage:   "override default S3 host for custom services",
 			EnvVars: []string{"S3_ENDPOINT_URL"},
 		},
 		&cli.BoolFlag{

--- a/command/app.go
+++ b/command/app.go
@@ -42,6 +42,7 @@ var app = &cli.App{
 		&cli.StringFlag{
 			Name:  "endpoint-url",
 			Usage: "override default S3 host for custom services",
+			EnvVars: []string{"S3_ENDPOINT_URL"},
 		},
 		&cli.BoolFlag{
 			Name:  "no-verify-ssl",


### PR DESCRIPTION
Make the `S3_ENDPOINT_URL` environment variable usable to omit the --endpoint-url flag.

Closes #326 