### PR TITLE
revert the append error commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,5 @@
 # Changelog
 
-### Features
-
-- Added `select` command. It allows to select JSON records from objects using SQL expressions. ([#299](https://github.com/peak/s5cmd/issues/299)) [@skeggse](https://github.com/skeggse)
-- Added `rb` command to remove buckets. ([#303](https://github.com/peak/s5cmd/issues/303)).
-- Added `--exclude` flag to `cp`, `rm`, `ls`, `du` and `select` commands. This flag allows users to exclude objects with given pattern. ([#266](https://github.com/peak/s5cmd/issues/266))
-- Added `--raw` flag to `cp` and `rm` commands. It disables the wildcard operations. It is useful when an object contains glob characters which interfers with glob expansion logic. ([#235](https://github.com/peak/s5cmd/issues/235))
-- Added `--cache-control` and `--expires` flags to `cp` and `mv` commands. It adds support for setting cache control and expires header to S3 objects. ([#318](https://github.com/peak/s5cmd/pull/318)) [@tombokombo](https://github.com/tombokombo)
-- Added `--force-glacier-transfer` flag to `cp` command. It forces a transfer request on all Glacier objects. ([#206](https://github.com/peak/s5cmd/issues/206))
-- Added `--source-region` and `destination-region` flags to `cp` command. It allows overriding bucket region. ([#262](https://github.com/peak/s5cmd/issues/262)) [@kemege](https://github.com/kemege)
-
-### Improvements
-
-- Added `MacPorts` installation option. ([#311](https://github.com/peak/s5cmd/pull/311)) [@manojkarthick](https://github.com/manojkarthick)
-
-### Bugfixes
-
-- Fixed a bug where errors did not result a non-zero exit code. ([#304](https://github.com/peak/s5cmd/issues/304))
-- Change the order of precedence in URL expansion in file system. Glob (*) expansion have precedence over directory expansion. ([#322](https://github.com/peak/s5cmd/pull/322))
-
 ## v1.3.0 - 1 Jul 2021
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 - Change the order of precedence in URL expansion in file system. Glob (*) expansion have precedence over directory expansion. ([#322](https://github.com/peak/s5cmd/pull/322))
 
-
 ## v1.3.0 - 1 Jul 2021
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### Features
+
+- Added `select` command. It allows to select JSON records from objects using SQL expressions. ([#299](https://github.com/peak/s5cmd/issues/299)) [@skeggse](https://github.com/skeggse)
+- Added `rb` command to remove buckets. ([#303](https://github.com/peak/s5cmd/issues/303)).
+- Added `--exclude` flag to `cp`, `rm`, `ls`, `du` and `select` commands. This flag allows users to exclude objects with given pattern. ([#266](https://github.com/peak/s5cmd/issues/266))
+- Added `--raw` flag to `cp` and `rm` commands. It disables the wildcard operations. It is useful when an object contains glob characters which interfers with glob expansion logic. ([#235](https://github.com/peak/s5cmd/issues/235))
+- Added `--cache-control` and `--expires` flags to `cp` and `mv` commands. It adds support for setting cache control and expires header to S3 objects. ([#318](https://github.com/peak/s5cmd/pull/318)) [@tombokombo](https://github.com/tombokombo)
+- Added `--force-glacier-transfer` flag to `cp` command. It forces a transfer request on all Glacier objects. ([#206](https://github.com/peak/s5cmd/issues/206))
+- Added `--source-region` and `destination-region` flags to `cp` command. It allows overriding bucket region. ([#262](https://github.com/peak/s5cmd/issues/262)) [@kemege](https://github.com/kemege)
+
+### Improvements
+
+- Added `MacPorts` installation option. ([#311](https://github.com/peak/s5cmd/pull/311)) [@manojkarthick](https://github.com/manojkarthick)
+
+### Bugfixes
+
+- Change the order of precedence in URL expansion in file system. Glob (*) expansion have precedence over directory expansion. ([#322](https://github.com/peak/s5cmd/pull/322))
+
+
 ## v1.3.0 - 1 Jul 2021
 
 #### Features

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -3249,7 +3249,6 @@ func TestCopyMultipleS3ObjectsToS3WithRawMode(t *testing.T) {
 		"file*.txt": "this is a test file 1",
 	}
 
-	// assert s3 objects in destination.
 	for filename, content := range expectedFiles {
 		assert.Assert(t, ensureS3Object(s3client, destBucket, filename, content))
 	}
@@ -3832,29 +3831,4 @@ func TestCopySingleS3ObjectsIntoAnotherBucketWithExcludeFilters(t *testing.T) {
 		err := ensureS3Object(s3client, dstbucket, filename, content)
 		assertError(t, err, errS3NoSuchKey)
 	}
-}
-
-func TestCopyExpectExitCode1OnUnreachableHost(t *testing.T) {
-	t.Parallel()
-
-	const bucket = "bucket"
-
-	_, s5cmd, cleanup := setup(t, withEndpointURL("nonExistingEndpointURL"))
-	defer cleanup()
-
-	folderLayout := []fs.PathOp{
-		fs.WithFile("testfile.txt", "this is a test file 1"),
-	}
-
-	workdir := fs.NewDir(t, "somedir", folderLayout...)
-	defer workdir.Remove()
-
-	src := fmt.Sprintf("s3://%s/*", bucket)
-	src = filepath.ToSlash(src)
-	dst := fmt.Sprintf("%v/", workdir.Path())
-
-	cmd := s5cmd("-r", "0", "cp", src, dst)
-	result := icmd.RunCmd(cmd)
-
-	result.Assert(t, icmd.Expected{ExitCode: 1})
 }

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -55,8 +55,7 @@ func init() {
 }
 
 type setupOpts struct {
-	s3backend   string
-	endpointURL string
+	s3backend string
 }
 
 type option func(*setupOpts)
@@ -64,12 +63,6 @@ type option func(*setupOpts)
 func withS3Backend(backend string) option {
 	return func(opts *setupOpts) {
 		opts.s3backend = backend
-	}
-}
-
-func withEndpointURL(url string) option {
-	return func(opts *setupOpts) {
-		opts.endpointURL = url
 	}
 }
 
@@ -84,7 +77,7 @@ func setup(t *testing.T, options ...option) (*s3.S3, func(...string) icmd.Cmd, f
 		option(opts)
 	}
 
-	endpoint, workdir, cleanup := server(t, opts)
+	endpoint, workdir, cleanup := server(t, opts.s3backend)
 
 	client := s3client(t, storage.Options{
 		Endpoint:    endpoint,
@@ -94,7 +87,7 @@ func setup(t *testing.T, options ...option) (*s3.S3, func(...string) icmd.Cmd, f
 	return client, s5cmd(workdir, endpoint), cleanup
 }
 
-func server(t *testing.T, setupOptions *setupOpts) (string, string, func()) {
+func server(t *testing.T, s3backend string) (string, string, func()) {
 	t.Helper()
 
 	// testdir := fs.NewDir() tries to create a new directory which
@@ -116,15 +109,13 @@ func server(t *testing.T, setupOptions *setupOpts) (string, string, func()) {
 		s3LogLevel = "info" // aws has no level other than 'debug'
 	}
 
-	endpoint, dbcleanup := s3ServerEndpoint(t, testdir, s3LogLevel, setupOptions.s3backend)
+	endpoint, dbcleanup := s3ServerEndpoint(t, testdir, s3LogLevel, s3backend)
 
 	cleanup := func() {
 		testdir.Remove()
 		dbcleanup()
 	}
-	if setupOptions.endpointURL != "" {
-		endpoint = setupOptions.endpointURL
-	}
+
 	return endpoint, workdir, cleanup
 }
 
@@ -167,7 +158,6 @@ func s5cmd(workdir, endpoint string) func(args ...string) icmd.Cmd {
 		)
 		cmd.Env = env
 		cmd.Dir = workdir
-
 		return cmd
 	}
 }


### PR DESCRIPTION
This PR is to revert the [9defce6b615f10bd2be785ca42cf510ce3642bf8](https://github.com/peak/s5cmd/commit/9defce6b615f10bd2be785ca42cf510ce3642bf8), which is opened to solve the #304. However, we get a new [issue](https://github.com/peak/s5cmd/issues/344) which points that the new change will break some code so we plan to include this reverted commit in new version 2.0.0

Resolves #344 