### PR TITLE
command/run: handle errors returned from parallel.Manager

### DIFF
--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -62,7 +62,7 @@ func TestRunFromStdinWithErrors(t *testing.T) {
 	cmd := s5cmd("run")
 	result := icmd.RunCmd(cmd, icmd.WithStdin(input))
 
-	result.Assert(t, icmd.Success)
+	result.Assert(t, icmd.Expected{ExitCode: 1})
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 


### PR DESCRIPTION
Run command ignores errors returned from `parallel.Manager`. I think it should be resolved in v2.0.0. Related to https://github.com/peak/s5cmd/issues/304