### PR TITLE
storage: fix region to work properly if bucket is specified

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -819,9 +819,13 @@ func (sc *SessionCache) clear() {
 }
 
 func setSessionRegion(ctx context.Context, sess *session.Session, bucket string) error {
-	if aws.StringValue(sess.Config.Region) == "" {
-		sess.Config.Region = aws.String(endpoints.UsEast1RegionID)
-	}
+	region := aws.StringValue(sess.Config.Region)
+
+	if region != "" {
+		return nil
+        }
+
+	sess.Config.Region = aws.String(endpoints.UsEast1RegionID)
 
 	if bucket == "" {
 		return nil


### PR DESCRIPTION
This is fix for Issue #354. custom region can be worked, but when if bucket is not specified.
Fix solves problem and user defined region works regardless bucket is specified.