### PR TITLE
.github/workflows: run ci on last the last 3 go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - 1.17.x
           - 1.16.x
           - 1.15.x
-          - 1.14.x
         os:
           - macos
           - ubuntu
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         go-version:
+          - 1.17.x
           - 1.16.x
           - 1.15.x
-          - 1.14.x
         os:
           - macos
           - ubuntu
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.16.x
+          - 1.17.x
         os:
           - ubuntu
 


### PR DESCRIPTION
I was just passing by and noticed CI was not running into the latest go version.
So I dropped 1.14 and added 1.17