### PR TITLE
fix: close result channel to fix hang

### DIFF
--- a/command/select.go
+++ b/command/select.go
@@ -188,6 +188,7 @@ func (s Select) Run(ctx context.Context) error {
 	}
 
 	waiter.Wait()
+	close(resultCh)
 	<-errDoneCh
 	<-writeDoneCh
 


### PR DESCRIPTION
Without this, the recv below hangs indefinitely, which prevents the `writeDoneCh` from closing, which prevents the entire process from completing. Not sure how I didn't catch this before?
https://github.com/peak/s5cmd/blob/ce2537d38ba030c7f278ca9d81007b7f33fd0faf/command/select.go#L142