### PR TITLE
Location of credentials for accessing Google Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ or an alternative with environment variable
 
 all variants will return your GCS buckets.
 
+`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. You will need to populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with  an HMAC key created using the Google Cloud console or `gsutil` to populate `.aws/credentials`
+
 `s5cmd` will use virtual-host style bucket resolving for S3, S3 transfer
 acceleration and GCS. If a custom endpoint is provided, it'll fallback to
 path-style.

--- a/README.md
+++ b/README.md
@@ -389,7 +389,6 @@ requests to AWS. Credentials can be provided in a variety of ways:
 The SDK detects and uses the built-in providers automatically, without requiring
 manual configurations.
 
-`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
 
 ### Region detection
 
@@ -431,7 +430,7 @@ or an alternative with environment variable
 
 all variants will return your GCS buckets.
 
-`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_id` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
+`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_id` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using this [procedure](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
 
 `s5cmd` will use virtual-host style bucket resolving for S3, S3 transfer
 acceleration and GCS. If a custom endpoint is provided, it'll fallback to

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ requests to AWS. Credentials can be provided in a variety of ways:
 The SDK detects and uses the built-in providers automatically, without requiring
 manual configurations.
 
+`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
+
 ### Region detection
 
 While executing the commands, `s5cmd` detects the region according to the following order of priority:
@@ -429,7 +431,7 @@ or an alternative with environment variable
 
 all variants will return your GCS buckets.
 
-`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. You will need to populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with  an HMAC key created using the Google Cloud console or `gsutil` to populate `.aws/credentials`
+`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
 
 `s5cmd` will use virtual-host style bucket resolving for S3, S3 transfer
 acceleration and GCS. If a custom endpoint is provided, it'll fallback to

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ or an alternative with environment variable
 
 all variants will return your GCS buckets.
 
-`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_ID` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
+`s5cmd` reads `.aws/credentials` to access Google Cloud Storage. Populate the `aws_access_key_id` and `aws_secret_access_key` fields in `.aws/credentials` with an HMAC key created using the Google Cloud console or `gsutil`.
 
 `s5cmd` will use virtual-host style bucket resolving for S3, S3 transfer
 acceleration and GCS. If a custom endpoint is provided, it'll fallback to


### PR DESCRIPTION
I could not figure out whether `s5cmd` was reading credentials from `.aws/credentials`, `.boto`, or some other location when accessing Google Cloud. Moreover, Google Cloud provides several options for providing keys. I figured out through trial and error that I needed to generate HMAC keys using the Google Cloud console or `gsutil` and entering them into `.aws/credentials`.