### PR TITLE
remove :unneeded from formula as deprecated

### DIFF
--- a/Formula/s5cmd.rb
+++ b/Formula/s5cmd.rb
@@ -6,7 +6,6 @@ class S5cmd < Formula
   desc "Parallel S3 and local filesystem execution tool"
   homepage "https://github.com/peak/s5cmd"
   version "1.4.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
unneeded is not long used by homebrew. see https://github.com/Homebrew/brew/pull/11239
