### PR TITLE
readme: update `Faster Beast Mode` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,10 +576,3 @@ significant runtime difference between those two approaches.
 # LICENSE
 
 MIT. See [LICENSE](https://github.com/peak/s5cmd/blob/master/LICENSE).
-
-
-
-===
-
-
-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

--- a/README.md
+++ b/README.md
@@ -547,11 +547,6 @@ The above command performs two `s5cmd` invocations; first, searches for files wi
 Let's examine another usage instance, where we migrate files older than
 30 days to a cloud object storage:
 
-    find /mnt/joshua/nachos/ -type f -mtime +30 | xargs -I{} echo “mv {} s3://joshuarobinson/backup/{}”
-    | s5cmd run
-
-, or, to avoid unnecessary exec calls in shell pipe:
-
     find /mnt/joshua/nachos/ -type f -mtime +30 | awk '{print "mv "$1" s3://joshuarobinson/backup/"$1}'
     | s5cmd run
 
@@ -581,3 +576,10 @@ significant runtime difference between those two approaches.
 # LICENSE
 
 MIT. See [LICENSE](https://github.com/peak/s5cmd/blob/master/LICENSE).
+
+
+
+===
+
+
+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

--- a/README.md
+++ b/README.md
@@ -421,10 +421,10 @@ object storage.
 or an alternative with environment variable
 
     S3_ENDPOINT_URL="https://storage.googleapis.com" s5cmd ls
-    
+
     # or
-    
-    export S3_ENDPOINT_URL="https://storage.googleapis.com" 
+
+    export S3_ENDPOINT_URL="https://storage.googleapis.com"
     s5cmd ls
 
 all variants will return your GCS buckets.
@@ -548,6 +548,11 @@ Let's examine another usage instance, where we migrate files older than
 30 days to a cloud object storage:
 
     find /mnt/joshua/nachos/ -type f -mtime +30 | xargs -I{} echo “mv {} s3://joshuarobinson/backup/{}”
+    | s5cmd run
+
+, or, to avoid unnecessary exec calls in shell pipe:
+
+    find /mnt/joshua/nachos/ -type f -mtime +30 | awk '{print "mv "$1" s3://joshuarobinson/backup/"$1}'
     | s5cmd run
 
 It is worth to mention that, `run` command should not be considered as a *silver bullet* for all operations. For example, assume we want to remove the following objects:


### PR DESCRIPTION
Since s5cmd is all about speed, I found it appropriate to propose a faster example for `find /path -type f |s5cmd run` :)
While ` | xargs -I{} echo`  is correct and works fine for most cases, it may be slow for very large lists.

For example, I need to transfer directory with 226K very small files in a tree:
```
anatolij@~$ time find /var/vault/data -type f | xargs -I{} echo "mv {} s3://bucket/vault/data/{}" > vault-data-file.cmd

real	4m34.096s
user	0m3.884s
sys	0m20.396s
```
More than 4 minutes (test executed at EC2 m5.large), just because it needs to exec two commands on each iteration.

Replacing it with `awk` gives us:
```
anatolij@~$ time find /var/vault/data -type f | awk '{print "mv "$1" s3://bucket/vault-awk/data/"$1}' > vault-data-file.awk.cmd

real	0m1.324s
user	0m0.720s
sys	0m0.816s
```

Both transferred filesets were identical:
```
anatolij@~$ wc -l vault-data-file.cmd vault-data-file.awk.cmd
   226519 vault-data-file.cmd
   226519 vault-data-file.awk.cmd

anatolij@~$ sha256sum vault-data-file.cmd vault-data-file.awk.cmd
  86c980f89664cf1cef98c36d2f171054d4e9e923414c6376e31067b6b638ed1d  vault-data-file.cmd
  86c980f89664cf1cef98c36d2f171054d4e9e923414c6376e31067b6b638ed1d  vault-data-file.awk.cmd
```

In my case of 200K tiny files ,  `| awk | s5cmd run` approach was 3-5 times faster than `| xargs echo| s5cmd run`   (300-400fps vs 900-1500fps).

BTW, thank you for the great tool!