### PR TITLE
command/run: print error if `run` argument doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bugfixes
 - Fixed a bug about precedence of region detection, which auto region detection would always override region defined in environment or profile. ([#325](https://github.com/peak/s5cmd/issues/325))
 - Fixed a bug where errors did not result a non-zero exit code. ([#304](https://github.com/peak/s5cmd/issues/304))
+- Print error if the commands file of `run` command is not accessible. ([#410](https://github.com/peak/s5cmd/pull/410))
 
 ## v1.4.0 - 21 Sep 2021
 

--- a/command/run.go
+++ b/command/run.go
@@ -51,6 +51,7 @@ func NewRunCommand() *cli.Command {
 			if c.Args().Len() == 1 {
 				f, err := os.Open(c.Args().First())
 				if err != nil {
+					printError(givenCommand(c), c.Command.Name, err)
 					return err
 				}
 				defer f.Close()

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -183,8 +183,8 @@ func TestRunFromFileThatDoesntExist(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
-		0: equals(`ERROR "run non-existent-file": open non-existent-file: no such file or directory`),
-	}, sortInput(true))
+		0: contains(`ERROR "run non-existent-file": open non-existent-file:`),
+	})
 }
 
 func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -169,6 +169,24 @@ func TestRunFromFileJSON(t *testing.T) {
 	assertLines(t, result.Stderr(), map[int]compareFunc{})
 }
 
+func TestRunFromFileThatDoesntExist(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd, cleanup := setup(t)
+	defer cleanup()
+
+	cmd := s5cmd("run", "non-existent-file")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+
+	assertLines(t, result.Stderr(), map[int]compareFunc{
+		0: equals(`ERROR "run non-existent-file": open non-existent-file: no such file or directory`),
+	}, sortInput(true))
+}
+
 func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Before:
```
$ ./s5cmd run cmd.tx
$ echo $?
1
```

After:
```
$ ./s5cmd run cmd.tx
ERROR "run cmd.tx": open cmd.tx: no such file or directory
$ echo $?
1
```
