### PR TITLE
Dockerfile: use `/aws` as working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apk add --no-cache git make && \
 
 FROM alpine:3.13
 COPY --from=build /s5cmd/s5cmd .
-ENTRYPOINT ["./s5cmd"]
+WORKDIR /aws
+ENTRYPOINT ["/s5cmd"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ development happens on `master` branch.
     $ docker pull peakcom/s5cmd
     $ docker run --rm -v ~/.aws:/root/.aws peakcom/s5cmd <S3 operation>
 
+ℹ️ For accesing host filesystem add `-v $(pwd):/aws` to `docker run` flags. Container uses `/aws/` as default working directory.
+
+⚠️ Note that only relative paths are allowed and only to files in `$(pwd)` and its subdirectories. Otherwise, the files won't be accessible in the container in the same way.
+
 #### Build
     $ git clone https://github.com/peak/s5cmd && cd s5cmd
     $ docker build -t s5cmd .


### PR DESCRIPTION
Changes relative path to absolute path so a user can easily mount his working dir to the docker
Add empty workdir similar to aws