### PR TITLE
command/run: drop inline comment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## not released yet
 
+#### Breaking changes
+- Dropped inline comment feature for `run` command. Previously s5cmd supported a command with an inline comment like `ls s3://bucket/object.gz  # inline comment` was supported. ([#309](https://github.com/peak/s5cmd/issues/309))
+
 #### Features
 - Added `--ignore-glacier-warnings` flag to `cp`, `mv` and `select` commands. ([#346](https://github.com/peak/s5cmd/issues/346))
-- Added `--force-glacier-transfer` flag to `select` command. ([#404](https://github.com/peak/s5cmd/pull/404))
+- Added `--force-glacier-transfer` flag to `select` command. ([#346](https://github.com/peak/s5cmd/issues/346))
 - Added AWS Single Sign-On (SSO) profiles support ([#385](https://github.com/peak/s5cmd/issues/385))
 - Added `--use-v1-api` flag to force using S3 ListObjects API instead of ListObjectsV2 API. ([#405](https://github.com/peak/s5cmd/issues/405)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## not released yet
 
 #### Breaking changes
-- Dropped inline comment feature for `run` command. Previously s5cmd supported a command with an inline comment like `ls s3://bucket/object.gz  # inline comment` was supported. ([#309](https://github.com/peak/s5cmd/issues/309))
+- Dropped inline comment feature for `run` command. Previously s5cmd supported a command with an inline comment like `ls s3://bucket/object.gz  # inline comment`. ([#309](https://github.com/peak/s5cmd/issues/309))
 
 #### Features
 - Added `--ignore-glacier-warnings` flag to `cp`, `mv` and `select` commands. ([#346](https://github.com/peak/s5cmd/issues/346))

--- a/command/run.go
+++ b/command/run.go
@@ -102,14 +102,12 @@ func (r Run) Run(ctx context.Context) error {
 	for line := range scanner.Scan() {
 		lineno++
 
-		// support inline comments
-		line = strings.Split(line, " #")[0]
-
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 
+		// skip comment lines
 		if strings.HasPrefix(line, "#") {
 			continue
 		}

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -25,9 +25,10 @@ func TestRunFromStdin(t *testing.T) {
 
 	input := strings.NewReader(
 		strings.Join([]string{
-			fmt.Sprintf("ls s3://%v/file1.txt", bucket),
 			" # this is a comment",
-			fmt.Sprintf("ls s3://%v/file2.txt # this is an inline comment", bucket),
+			fmt.Sprintf("ls s3://%v/file1.txt", bucket),
+			"# this one too",
+			fmt.Sprintf("ls s3://%v/file2.txt", bucket),
 		}, "\n"),
 	)
 	cmd := s5cmd("run")


### PR DESCRIPTION
Previously s5cmd supported a command with an inline comment like `ls s3://bucket/object.gz  # inline comment`.

Comment per line is still supported.

Fixes #309
