### PR TITLE
command/sync: create source client only for local objects

### DIFF
--- a/command/sync.go
+++ b/command/sync.go
@@ -180,6 +180,9 @@ func (s Sync) Run(c *cli.Context) error {
 
 	onlySource, onlyDest, commonObjects := compareObjects(sourceObjects, destObjects)
 
+	sourceObjects = nil
+	destObjects = nil
+
 	waiter := parallel.NewWaiter()
 	var (
 		merrorWaiter error


### PR DESCRIPTION
Source client is used for understanding whether the source object is a directory.  Don't create it if the source is remote or batch.