### PR TITLE
add AWS_DEBUG environment variable to print SDK debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 - Added `--force-glacier-transfer` flag to `select` command. ([#346](https://github.com/peak/s5cmd/issues/346))
 - Added AWS Single Sign-On (SSO) profiles support ([#385](https://github.com/peak/s5cmd/issues/385))
 - Added `--use-list-objects-v1` flag to force using S3 ListObjects API instead of ListObjectsV2 API. ([#405](https://github.com/peak/s5cmd/issues/405)
+- Added `AWS_DEBUG` environment variable to print SDK debug logs.
 
 #### Improvements
 - Upgrade minimum required Go version to 1.16.
-- Print SDK debug logs if log level is set to debug and `--json` flag is not given.
 
 #### Bugfixes
 - Fixed a bug about precedence of region detection, which auto region detection would always override region defined in environment or profile. ([#325](https://github.com/peak/s5cmd/issues/325))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 - Added `--use-list-objects-v1` flag to force using S3 ListObjects API instead of ListObjectsV2 API. ([#405](https://github.com/peak/s5cmd/issues/405)
 
 #### Improvements
-
 - Upgrade minimum required Go version to 1.16.
+- Print SDK debug logs if log level is set to debug and `--json` flag is not given.
 
 #### Bugfixes
 - Fixed a bug about precedence of region detection, which auto region detection would always override region defined in environment or profile. ([#325](https://github.com/peak/s5cmd/issues/325))

--- a/README.md
+++ b/README.md
@@ -494,6 +494,12 @@ ERROR "cp s3://somebucket/file.txt file.txt": object already exists
     "error": "'cp s3://somebucket/file.txt file.txt': object already exists"
 }
 ```
+
+* If you want to enable SDK-level debug logs, set `AWS_DEBUG` environment variable:
+
+```shell
+AWS_DEBUG=True s5cmd cp s3://somebucket/file.txt file.txt
+```
 ## Benchmarks
 Some benchmarks regarding the performance of `s5cmd` are introduced below. For more
 details refer to this [post](https://medium.com/@joshua_robinson/s5cmd-for-high-performance-object-storage-7071352cc09d)

--- a/command/app.go
+++ b/command/app.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	cmpinstall "github.com/posener/complete/cmd/install"
 	"github.com/urfave/cli/v2"
@@ -142,13 +141,7 @@ var app = &cli.App{
 
 // NewStorageOpts creates storage.Options object from the given context.
 func NewStorageOpts(c *cli.Context) storage.Options {
-	debug := false
-	if !c.Bool("json") && strings.EqualFold(c.String("log"), "debug") {
-		debug = true
-	}
-
 	return storage.Options{
-		Debug:            debug,
 		DryRun:           c.Bool("dry-run"),
 		Endpoint:         c.String("endpoint-url"),
 		MaxRetries:       c.Int("retry-count"),

--- a/command/app.go
+++ b/command/app.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	cmpinstall "github.com/posener/complete/cmd/install"
 	"github.com/urfave/cli/v2"
@@ -141,14 +142,20 @@ var app = &cli.App{
 
 // NewStorageOpts creates storage.Options object from the given context.
 func NewStorageOpts(c *cli.Context) storage.Options {
+	debug := false
+	if !c.Bool("json") && strings.EqualFold(c.String("log"), "debug") {
+		debug = true
+	}
+
 	return storage.Options{
-		MaxRetries:       c.Int("retry-count"),
-		Endpoint:         c.String("endpoint-url"),
-		NoVerifySSL:      c.Bool("no-verify-ssl"),
+		Debug:            debug,
 		DryRun:           c.Bool("dry-run"),
+		Endpoint:         c.String("endpoint-url"),
+		MaxRetries:       c.Int("retry-count"),
 		NoSignRequest:    c.Bool("no-sign-request"),
-		UseListObjectsV1: c.Bool("use-list-objects-v1"),
+		NoVerifySSL:      c.Bool("no-verify-ssl"),
 		RequestPayer:     c.String("request-payer"),
+		UseListObjectsV1: c.Bool("use-list-objects-v1"),
 	}
 }
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -792,6 +792,10 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithS3UseAccelerate(useAccelerate).
 		WithHTTPClient(httpClient)
 
+	if opts.Debug {
+		awsCfg = awsCfg.WithLogLevel(aws.LogDebug)
+	}
+
 	awsCfg.Retryer = newCustomRetryer(opts.MaxRetries)
 
 	useSharedConfig := session.SharedConfigEnable

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -792,7 +792,8 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithS3UseAccelerate(useAccelerate).
 		WithHTTPClient(httpClient)
 
-	if opts.Debug {
+	debug := os.Getenv("AWS_DEBUG")
+	if strings.EqualFold(debug, "True") {
 		awsCfg = awsCfg.WithLogLevel(aws.LogDebug)
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -48,6 +48,7 @@ func NewLocalClient(opts Options) *Filesystem {
 
 func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, error) {
 	newOpts := Options{
+		Debug:            opts.Debug,
 		MaxRetries:       opts.MaxRetries,
 		Endpoint:         opts.Endpoint,
 		NoVerifySSL:      opts.NoVerifySSL,
@@ -76,6 +77,7 @@ type Options struct {
 	DryRun           bool
 	NoSignRequest    bool
 	UseListObjectsV1 bool
+	Debug            bool
 	RequestPayer     string
 	bucket           string
 	region           string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -48,7 +48,6 @@ func NewLocalClient(opts Options) *Filesystem {
 
 func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, error) {
 	newOpts := Options{
-		Debug:            opts.Debug,
 		MaxRetries:       opts.MaxRetries,
 		Endpoint:         opts.Endpoint,
 		NoVerifySSL:      opts.NoVerifySSL,
@@ -77,7 +76,6 @@ type Options struct {
 	DryRun           bool
 	NoSignRequest    bool
 	UseListObjectsV1 bool
-	Debug            bool
 	RequestPayer     string
 	bucket           string
 	region           string


### PR DESCRIPTION
I think it is useful to add feature for printing aws-sdk debug logs. Example:

```
❯ AWS_DEBUG=True ./s5cmd cp s3://examplebucket/a a
2022/04/07 12:20:43 DEBUG: Request s3/GetObject Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET /a HTTP/1.1
Host: ***
User-Agent: aws-sdk-go/1.40.25 (go1.18; darwin; amd64) S3Manager
Authorization: ***
Range: bytes=0-52428799
X-Amz-Content-Sha256: ***
X-Amz-Date: 20220407T092043Z
X-Amz-Security-Token: ***

-----------------------------------------------------
2022/04/07 12:20:44 DEBUG: Response s3/GetObject Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 404 Not Found
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Thu, 07 Apr 2022 09:20:44 GMT
Server: AmazonS3
X-Amz-Id-2: ***
X-Amz-Request-Id: ***


-----------------------------------------------------
ERROR "cp s3://examplebucket/a a": NoSuchKey: The specified key does not exist. status code: 404, request id: ***, host id: ***

```