### PR TITLE
command/run: handle large tokens in scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed a bug where errors did not result a non-zero exit code. ([#304](https://github.com/peak/s5cmd/issues/304))
 - Print error if the commands file of `run` command is not accessible. ([#410](https://github.com/peak/s5cmd/pull/410))
 - Updated region detection call to use current session's address resolving method ([#314](https://github.com/peak/s5cmd/issues/314))
+- Fixed a bug where lines with large tokens fail in `run` command. `sync` was failing when it finds multiple files to remove. ([#435](https://github.com/peak/s5cmd/issues/435), [#436](https://github.com/peak/s5cmd/issues/436))
 
 ## v1.4.0 - 21 Sep 2021
 

--- a/command/run.go
+++ b/command/run.go
@@ -195,7 +195,7 @@ func (s *Scanner) scan() {
 			// it returns the data read before the error and the error itself (often io.EOF).
 			line, err := s.ReadString('\n')
 			if line != "" {
-				s.linech <- strings.TrimSpace(line)
+				s.linech <- line
 			}
 			if err != nil {
 				if err == io.EOF {

--- a/command/run.go
+++ b/command/run.go
@@ -82,7 +82,6 @@ func NewRun(c *cli.Context, r io.Reader) Run {
 }
 
 func (r Run) Run(ctx context.Context) error {
-	reader := r.reader
 	pm := parallel.New(r.numWorkers)
 	defer pm.Close()
 
@@ -97,10 +96,10 @@ func (r Run) Run(ctx context.Context) error {
 		}
 	}()
 
-	scanner := NewScanner(ctx, reader)
+	reader := NewReader(ctx, r.reader)
 
 	lineno := -1
-	for line := range scanner.Scan() {
+	for line := range reader.Read() {
 		lineno++
 
 		line = strings.TrimSpace(line)
@@ -154,71 +153,71 @@ func (r Run) Run(ctx context.Context) error {
 	waiter.Wait()
 	<-errDoneCh
 
-	if scanner.Err() != nil {
-		printError(commandFromContext(r.c), r.c.Command.Name, scanner.Err())
+	if reader.Err() != nil {
+		printError(commandFromContext(r.c), r.c.Command.Name, reader.Err())
 	}
 
-	return multierror.Append(merrorWaiter, scanner.Err()).ErrorOrNil()
+	return multierror.Append(merrorWaiter, reader.Err()).ErrorOrNil()
 }
 
-// Scanner is a cancelable scanner.
-type Scanner struct {
+// Reader is a cancelable reader.
+type Reader struct {
 	*bufio.Reader
 	err    error
 	linech chan string
 	ctx    context.Context
 }
 
-// NewScanner creates a new scanner with cancellation.
-func NewScanner(ctx context.Context, r io.Reader) *Scanner {
-	scanner := &Scanner{
+// NewReader creates a new reader with cancellation.
+func NewReader(ctx context.Context, r io.Reader) *Reader {
+	reader := &Reader{
 		ctx:    ctx,
 		Reader: bufio.NewReader(r),
 		linech: make(chan string),
 	}
 
-	go scanner.scan()
-	return scanner
+	go reader.read()
+	return reader
 }
 
-// scan read the underlying reader.
-func (s *Scanner) scan() {
-	defer close(s.linech)
+// read reads lines from the underlying reader.
+func (r *Reader) read() {
+	defer close(r.linech)
 
 	for {
 		select {
-		case <-s.ctx.Done():
-			s.err = s.ctx.Err()
+		case <-r.ctx.Done():
+			r.err = r.ctx.Err()
 			return
 		default:
 			// If ReadString encounters an error before finding a delimiter,
 			// it returns the data read before the error and the error itself (often io.EOF).
-			line, err := s.ReadString('\n')
+			line, err := r.ReadString('\n')
 			if line != "" {
-				s.linech <- line
+				r.linech <- line
 			}
 			if err != nil {
 				if err == io.EOF {
 					return
 				}
-				s.err = multierror.Append(s.err, err)
+				r.err = multierror.Append(r.err, err)
 			}
 		}
 	}
 }
 
-// Scan returns read-only channel to consume lines.
-func (s *Scanner) Scan() <-chan string {
-	return s.linech
+// Read returns read-only channel to consume lines.
+func (r *Reader) Read() <-chan string {
+	return r.linech
 }
 
 // Err returns encountered errors, if any.
-func (s *Scanner) Err() error {
-	if errors.Is(s.err, context.Canceled) {
+func (r *Reader) Err() error {
+	if errors.Is(r.err, context.Canceled) {
 		return context.Canceled
 	}
 
-	return s.err
+	return r.err
 }
 
 func validateRunCommand(c *cli.Context) error {

--- a/command/run.go
+++ b/command/run.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bufio"
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -213,10 +212,6 @@ func (r *Reader) Read() <-chan string {
 
 // Err returns encountered errors, if any.
 func (r *Reader) Err() error {
-	if errors.Is(r.err, context.Canceled) {
-		return context.Canceled
-	}
-
 	return r.err
 }
 

--- a/command/run.go
+++ b/command/run.go
@@ -235,7 +235,7 @@ func (s *Scanner) Err() error {
 		return context.Canceled
 	}
 
-	return multierror.Append(s.err).ErrorOrNil()
+	return s.err
 }
 
 func validateRunCommand(c *cli.Context) error {

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -1622,7 +1622,7 @@ func TestSyncLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 	}
 }
 
-// rm s3://bucket/* (removes 10k objects)
+// sync --delete somedir s3://bucket/ (removes 10k objects)
 func TestIssue435(t *testing.T) {
 	t.Parallel()
 

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -1621,3 +1621,59 @@ func TestSyncLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 		})
 	}
 }
+
+// rm s3://bucket/* (removes 10k objects)
+func TestIssue435(t *testing.T) {
+	t.Parallel()
+
+	bucket := s3BucketFromTestName(t)
+
+	s3client, s5cmd, cleanup := setup(t, withS3Backend("mem"))
+	defer cleanup()
+
+	createBucket(t, s3client, bucket)
+
+	// empty folder
+	folderLayout := []fs.PathOp{}
+
+	workdir := fs.NewDir(t, "somedir", folderLayout...)
+	defer workdir.Remove()
+
+	const filecount = 10_000
+
+	filenameFunc := func(i int) string { return fmt.Sprintf("file_%06d", i) }
+	contentFunc := func(i int) string { return fmt.Sprintf("file body %06d", i) }
+
+	for i := 0; i < filecount; i++ {
+		filename := filenameFunc(i)
+		content := contentFunc(i)
+		putFile(t, s3client, bucket, filename, content)
+	}
+
+	src := fmt.Sprintf("%v/", workdir.Path())
+	src = filepath.ToSlash(src)
+	dst := fmt.Sprintf("s3://%v/", bucket)
+
+	cmd := s5cmd("--log", "debug", "sync", "--delete", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stderr(), map[int]compareFunc{})
+
+	expected := make(map[int]compareFunc)
+	for i := 0; i < filecount; i++ {
+		expected[i] = contains("rm s3://%v/file_%06d", bucket, i)
+	}
+
+	assertLines(t, result.Stdout(), expected, sortInput(true))
+
+	// assert s3 objects
+	for i := 0; i < filecount; i++ {
+		filename := filenameFunc(i)
+		content := contentFunc(i)
+
+		err := ensureS3Object(s3client, bucket, filename, content)
+		assertError(t, err, errS3NoSuchKey)
+	}
+}


### PR DESCRIPTION
Fixes #435, fixes #436

Sync uses `run` interface to execute commands. Run scans given `io.Reader` and creates a command from each line. If sync finds multiple files to remove, generated command string exceeds the maximum token size of bufio.Scanner and we are getting `bufio.Scanner: token too long` errors. As described in the issues, `sync` fails if it tries to remove a large number of files. 

[Official go documentation](https://pkg.go.dev/bufio) recommends using `bufio.Reader` for handling large tokens: 

```
Programs that need more control over error handling or large tokens, or must run sequential scans 
on a reader, should use bufio.Reader instead.
```

This PR fixes two bugs:

1. Currently, scanner errors are ignored, and commands silently fail if we encounter scanner errors. Always print scanner errors before exiting the command.

2. Use `bufio.Reader` instead of `bufio.Scanner` to handle large tokens.
 