### PR TITLE
storage: add profile flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## not released yet
 
+#### Features
+- Added `--profile` flag to allow users to specify a [named profile]. ([#353](https://github.com/peak/s5cmd/issues/353))
+
 
 ## v2.0.0 - 4 Jul 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Features
 - Added `--profile` flag to allow users to specify a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). ([#353](https://github.com/peak/s5cmd/issues/353))
-- Added `--credential-file` flag to allow users to specify path for the AWS credentials file instead of using the [default location](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where). 
+- Added `--credentials-file` flag (with `--cf` alias) to allow users to specify path for the AWS credentials file instead of using the [default location](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where). 
 
 
 ## v2.0.0 - 4 Jul 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Features
 - Added `--profile` flag to allow users to specify a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). ([#353](https://github.com/peak/s5cmd/issues/353))
-- Added `--credentials-file` flag (with `--cf` alias) to allow users to specify path for the AWS credentials file instead of using the [default location](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where). 
+- Added `--credentials-file` flag to allow users to specify path for the AWS credentials file instead of using the [default location](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where). 
 
 #### Improvements
 - Disable AWS SDK logger if log level is not "trace"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Features
 - Added `--profile` flag to allow users to specify a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). ([#353](https://github.com/peak/s5cmd/issues/353))
+- Added `--credential-file` flag to allow users to specify path for the AWS credentials file instead of using the [default location](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where). 
 
 
 ## v2.0.0 - 4 Jul 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## not released yet
 
 #### Features
-- Added `--profile` flag to allow users to specify a [named profile]. ([#353](https://github.com/peak/s5cmd/issues/353))
+- Added `--profile` flag to allow users to specify a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). ([#353](https://github.com/peak/s5cmd/issues/353))
 
 
 ## v2.0.0 - 4 Jul 2022

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ s5cmd --use-list-objects-v1 ls s3://bucket/
 
 `s5cmd` uses official AWS SDK to access S3. SDK requires credentials to sign
 requests to AWS. Credentials can be provided in a variety of ways:
-- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), `--credentials-file` flag (or its alias `--cf`) to use specified credentials file, and `--no-sign-request` to send requests anonymously
+- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), `--credentials-file` flag to use the specified credentials file, and `--no-sign-request` to send requests anonymously
 - Environment variables
 - AWS credentials file, including profile selection via `AWS_PROFILE` environment
   variable

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ s5cmd --use-list-objects-v1 ls s3://bucket/
 
 `s5cmd` uses official AWS SDK to access S3. SDK requires credentials to sign
 requests to AWS. Credentials can be provided in a variety of ways:
-- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), `--credential-file` flag to use specified credentials file, and `--no-sign-request` to send requests anonymously
+- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), `--credentials-file` flag (or its alias `--cf`) to use specified credentials file, and `--no-sign-request` to send requests anonymously
 - Environment variables
 - AWS credentials file, including profile selection via `AWS_PROFILE` environment
   variable

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ s5cmd --use-list-objects-v1 ls s3://bucket/
 
 `s5cmd` uses official AWS SDK to access S3. SDK requires credentials to sign
 requests to AWS. Credentials can be provided in a variety of ways:
-
+- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) and `--no-sign-request` to send requests anonymously
 - Environment variables
 - AWS credentials file, including profile selection via `AWS_PROFILE` environment
   variable

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ s5cmd --use-list-objects-v1 ls s3://bucket/
 
 `s5cmd` uses official AWS SDK to access S3. SDK requires credentials to sign
 requests to AWS. Credentials can be provided in a variety of ways:
-- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) and `--no-sign-request` to send requests anonymously
+- Command line options `--profile` to use a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), `--credential-file` flag to use specified credentials file, and `--no-sign-request` to send requests anonymously
 - Environment variables
 - AWS credentials file, including profile selection via `AWS_PROFILE` environment
   variable

--- a/command/app.go
+++ b/command/app.go
@@ -83,7 +83,7 @@ var app = &cli.App{
 		},
 		&cli.StringFlag{
 			Name:  "profile",
-			Usage: "use the specified `ProfileName` from the credential file",
+			Usage: "use the specified profile from the credential file",
 		},
 	},
 	Before: func(c *cli.Context) error {

--- a/command/app.go
+++ b/command/app.go
@@ -85,6 +85,10 @@ var app = &cli.App{
 			Name:  "profile",
 			Usage: "use the specified profile from the credential file",
 		},
+		&cli.StringFlag{
+			Name:  "credential-file",
+			Usage: "use the specified credential file instead of the default",
+		},
 	},
 	Before: func(c *cli.Context) error {
 		retryCount := c.Int("retry-count")
@@ -103,6 +107,11 @@ var app = &cli.App{
 		}
 		if c.Bool("no-sign-request") && c.String("profile") != "" {
 			err := fmt.Errorf(`"no-sign-request" and "profile" flags cannot be used together`)
+			printError(commandFromContext(c), c.Command.Name, err)
+			return err
+		}
+		if c.Bool("no-sign-request") && c.String("credential-file") != "" {
+			err := fmt.Errorf(`"no-sign-request" and "credential-file" flags cannot be used together`)
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
 		}
@@ -172,6 +181,7 @@ func NewStorageOpts(c *cli.Context) storage.Options {
 		RequestPayer:     c.String("request-payer"),
 		UseListObjectsV1: c.Bool("use-list-objects-v1"),
 		Profile:          c.String("profile"),
+		CredentialFile:   c.String("credential-file"),
 	}
 }
 

--- a/command/app.go
+++ b/command/app.go
@@ -100,6 +100,10 @@ var app = &cli.App{
 			err := fmt.Errorf("retry count cannot be a negative value")
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
+		} else if c.Bool("no-verify-ssl") && c.String("profile") != "" {
+			err := fmt.Errorf(`"no-verify-ssl" and "profile" flags cannot be used together`)
+			printError(commandFromContext(c), c.Command.Name, err)
+			return err
 		}
 
 		if isStat {

--- a/command/app.go
+++ b/command/app.go
@@ -100,8 +100,9 @@ var app = &cli.App{
 			err := fmt.Errorf("retry count cannot be a negative value")
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
-		} else if c.Bool("no-verify-ssl") && c.String("profile") != "" {
-			err := fmt.Errorf(`"no-verify-ssl" and "profile" flags cannot be used together`)
+		}
+		if c.Bool("no-sign-request") && c.String("profile") != "" {
+			err := fmt.Errorf(`"no-sign-request" and "profile" flags cannot be used together`)
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
 		}

--- a/command/app.go
+++ b/command/app.go
@@ -86,9 +86,8 @@ var app = &cli.App{
 			Usage: "use the specified profile from the credentials file",
 		},
 		&cli.StringFlag{
-			Name:    "credentials-file",
-			Aliases: []string{"cf"},
-			Usage:   "use the specified credentials file instead of the default credentials file",
+			Name:  "credentials-file",
+			Usage: "use the specified credentials file instead of the default credentials file",
 		},
 	},
 	Before: func(c *cli.Context) error {

--- a/command/app.go
+++ b/command/app.go
@@ -83,11 +83,12 @@ var app = &cli.App{
 		},
 		&cli.StringFlag{
 			Name:  "profile",
-			Usage: "use the specified profile from the credential file",
+			Usage: "use the specified profile from the credentials file",
 		},
 		&cli.StringFlag{
-			Name:  "credential-file",
-			Usage: "use the specified credential file instead of the default",
+			Name:    "credentials-file",
+			Aliases: []string{"cf"},
+			Usage:   "use the specified credentials file instead of the default credentials file",
 		},
 	},
 	Before: func(c *cli.Context) error {
@@ -110,8 +111,8 @@ var app = &cli.App{
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
 		}
-		if c.Bool("no-sign-request") && c.String("credential-file") != "" {
-			err := fmt.Errorf(`"no-sign-request" and "credential-file" flags cannot be used together`)
+		if c.Bool("no-sign-request") && c.String("credentials-file") != "" {
+			err := fmt.Errorf(`"no-sign-request" and "credentials-file" flags cannot be used together`)
 			printError(commandFromContext(c), c.Command.Name, err)
 			return err
 		}
@@ -181,7 +182,7 @@ func NewStorageOpts(c *cli.Context) storage.Options {
 		RequestPayer:     c.String("request-payer"),
 		UseListObjectsV1: c.Bool("use-list-objects-v1"),
 		Profile:          c.String("profile"),
-		CredentialFile:   c.String("credential-file"),
+		CredentialFile:   c.String("credentials-file"),
 	}
 }
 

--- a/command/app.go
+++ b/command/app.go
@@ -81,6 +81,10 @@ var app = &cli.App{
 			Name:  "request-payer",
 			Usage: "who pays for request (access requester pays buckets)",
 		},
+		&cli.StringFlag{
+			Name:  "profile",
+			Usage: "use the specified `ProfileName` from the credential file",
+		},
 	},
 	Before: func(c *cli.Context) error {
 		retryCount := c.Int("retry-count")
@@ -162,6 +166,7 @@ func NewStorageOpts(c *cli.Context) storage.Options {
 		NoVerifySSL:      c.Bool("no-verify-ssl"),
 		RequestPayer:     c.String("request-payer"),
 		UseListObjectsV1: c.Bool("use-list-objects-v1"),
+		Profile:          c.String("profile"),
 	}
 }
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -771,6 +771,8 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 	if opts.NoSignRequest {
 		// do not sign requests when making service API calls
 		awsCfg.Credentials = credentials.AnonymousCredentials
+	} else if opts.Profile != "" { // if they provided a profile
+		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials("", opts.Profile))
 	}
 
 	endpointURL, err := parseEndpoint(opts.Endpoint)

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -771,7 +771,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 	if opts.NoSignRequest {
 		// do not sign requests when making service API calls
 		awsCfg = awsCfg.WithCredentials(credentials.AnonymousCredentials)
-	} else if opts.Profile != "" { // if they provided a profile
+	} else if opts.Profile != "" {
 		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials("", opts.Profile))
 	}
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -770,7 +770,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 
 	if opts.NoSignRequest {
 		// do not sign requests when making service API calls
-		awsCfg.Credentials = credentials.AnonymousCredentials
+		awsCfg = awsCfg.WithCredentials(credentials.AnonymousCredentials)
 	} else if opts.Profile != "" { // if they provided a profile
 		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials("", opts.Profile))
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -771,8 +771,10 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 	if opts.NoSignRequest {
 		// do not sign requests when making service API calls
 		awsCfg = awsCfg.WithCredentials(credentials.AnonymousCredentials)
-	} else if opts.Profile != "" {
-		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials("", opts.Profile))
+	} else if opts.CredentialFile != "" || opts.Profile != "" {
+		awsCfg = awsCfg.WithCredentials(
+			credentials.NewSharedCredentials(opts.CredentialFile, opts.Profile),
+		)
 	}
 
 	endpointURL, err := parseEndpoint(opts.Endpoint)

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -129,7 +129,7 @@ func TestNewSessionWithNoSignRequest(t *testing.T) {
 }
 
 func TestNewSessionWithProfileFromFile(t *testing.T) {
-	// create a temporary credential file
+	// create a temporary credentials file
 	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -142,8 +142,7 @@ func TestNewSessionWithProfile(t *testing.T) {
 	expected, _ := credentials.NewSharedCredentials("", profileName).Get()
 
 	if expected != got {
-		t.Fatalf("expected credentials does not match the credential we got! (To avoid unintended credential leaks, we don't print them here.)")
-		//t.Fatalf("expected %v, got %v", expected, got)
+		t.Error("expected profile credentials does not match the credential we got!")
 	}
 }
 

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -128,6 +128,25 @@ func TestNewSessionWithNoSignRequest(t *testing.T) {
 	}
 }
 
+func TestNewSessionWithProfile(t *testing.T) {
+	globalSessionCache.clear()
+	profileName := "default"
+	sess, err := globalSessionCache.newSession(context.Background(), Options{
+		Profile: profileName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := sess.Config.Credentials.Get()
+	expected, _ := credentials.NewSharedCredentials("", profileName).Get()
+
+	if expected != got {
+		t.Fatalf("expected credentials does not match the credential we got! (To avoid unintended credential leaks, we don't print them here.)")
+		//t.Fatalf("expected %v, got %v", expected, got)
+	}
+}
+
 func TestS3ListURL(t *testing.T) {
 	url, err := url.New("s3://bucket/key")
 	if err != nil {

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -146,11 +146,7 @@ aws_secret_access_key = p1_profile_access_key
 
 [p2]
 aws_access_key_id = p2_profile_key_id
-aws_secret_access_key = p2_profile_access_key
-
-[p3]
-aws_access_key_id = p3_profile_key_id
-aws_secret_access_key = p3_profile_access_key`
+aws_secret_access_key = p2_profile_access_key`
 
 	_, err = file.Write([]byte(profiles))
 	if err != nil {
@@ -158,64 +154,59 @@ aws_secret_access_key = p3_profile_access_key`
 	}
 
 	testcases := []struct {
+		name               string
 		fileName           string
 		profileName        string
 		expAccessKeyId     string
 		expSecretAccessKey string
 	}{
 		{
+			name:               "use default profile",
 			fileName:           file.Name(),
 			profileName:        "",
 			expAccessKeyId:     "default_profile_key_id",
 			expSecretAccessKey: "default_profile_access_key",
 		},
 		{
+			name:               "use a non-default profile",
 			fileName:           file.Name(),
 			profileName:        "p1",
 			expAccessKeyId:     "p1_profile_key_id",
 			expSecretAccessKey: "p1_profile_access_key",
 		},
 		{
+
+			name:               "use a non-existent profile",
 			fileName:           file.Name(),
 			profileName:        "non-existent-profile",
 			expAccessKeyId:     "",
 			expSecretAccessKey: "",
 		},
-		{
-			fileName:           file.Name(),
-			profileName:        "p2",
-			expAccessKeyId:     "p2_profile_key_id",
-			expSecretAccessKey: "p2_profile_access_key",
-		},
-		{
-			fileName:           file.Name(),
-			profileName:        "p3",
-			expAccessKeyId:     "p3_profile_key_id",
-			expSecretAccessKey: "p3_profile_access_key",
-		},
 	}
 	for _, tc := range testcases {
-		globalSessionCache.clear()
-		sess, err := globalSessionCache.newSession(context.Background(), Options{
-			Profile:        tc.profileName,
-			CredentialFile: tc.fileName,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		got, err := sess.Config.Credentials.Get()
-		if err != nil {
-			// if there should not be such as profile continue,
-			if tc.expAccessKeyId == "" && tc.expSecretAccessKey == "" {
-				continue
+		t.Run(tc.name, func(t *testing.T) {
+			globalSessionCache.clear()
+			sess, err := globalSessionCache.newSession(context.Background(), Options{
+				Profile:        tc.profileName,
+				CredentialFile: tc.fileName,
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
-			t.Fatal(err)
-		}
 
-		if got.AccessKeyID != tc.expAccessKeyId || got.SecretAccessKey != tc.expSecretAccessKey {
-			t.Errorf("Expected credentials does not match the credential we got!\nExpected: Access Key ID: %v, Secret Access Key: %v\nGot    : Access Key ID: %v, Secret Access Key: %v\n", tc.expAccessKeyId, tc.expSecretAccessKey, got.AccessKeyID, got.SecretAccessKey)
-		}
+			got, err := sess.Config.Credentials.Get()
+			if err != nil {
+				// if there should be such a profile but received an error fail,
+				// ignore the error otherwise.
+				if tc.expAccessKeyId != "" || tc.expSecretAccessKey != "" {
+					t.Fatal(err)
+				}
+			}
+
+			if got.AccessKeyID != tc.expAccessKeyId || got.SecretAccessKey != tc.expSecretAccessKey {
+				t.Errorf("Expected credentials does not match the credential we got!\nExpected: Access Key ID: %v, Secret Access Key: %v\nGot    : Access Key ID: %v, Secret Access Key: %v\n", tc.expAccessKeyId, tc.expSecretAccessKey, got.AccessKeyID, got.SecretAccessKey)
+			}
+		})
 	}
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -55,6 +55,7 @@ func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, erro
 		NoSignRequest:    opts.NoSignRequest,
 		UseListObjectsV1: opts.UseListObjectsV1,
 		RequestPayer:     opts.RequestPayer,
+		Profile:          opts.Profile,
 		bucket:           url.Bucket,
 		region:           opts.region,
 	}
@@ -77,6 +78,7 @@ type Options struct {
 	NoSignRequest    bool
 	UseListObjectsV1 bool
 	RequestPayer     string
+	Profile          string
 	bucket           string
 	region           string
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -56,6 +56,7 @@ func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, erro
 		UseListObjectsV1: opts.UseListObjectsV1,
 		RequestPayer:     opts.RequestPayer,
 		Profile:          opts.Profile,
+		CredentialFile:   opts.CredentialFile,
 		bucket:           url.Bucket,
 		region:           opts.region,
 	}
@@ -79,6 +80,7 @@ type Options struct {
 	UseListObjectsV1 bool
 	RequestPayer     string
 	Profile          string
+	CredentialFile   string
 	bucket           string
 	region           string
 }


### PR DESCRIPTION
This commit adds `--profile` flag to allow users to specify a [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) rather than using the default.

Fixes #353