### PR TITLE
storage/s3: Fix proxy with no-verify-ssl flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## not released yet
 
+#### Bugfixes
+- Fixed a bug where proxy is not being used when `--no-verify-ssl` flag is used. ([#445](https://github.com/peak/s5cmd/issues/445))
+
 
 ## v2.0.0 - 4 Jul 2022
 
@@ -31,7 +34,6 @@
 - Fixed a bug where lines with large tokens fail in `run` command. `sync` was failing when it finds multiple files to remove. ([#435](https://github.com/peak/s5cmd/issues/435), [#436](https://github.com/peak/s5cmd/issues/436))
 - Print usage error if given log level(`--log`) is not valid. ([#430](https://github.com/peak/s5cmd/pull/430))
 - Fixed a bug where (`--stat`) is ignored when log level is error. ([#359](https://github.com/peak/s5cmd/issues/359))
-- Fixed a bug where proxy is not being used when `--no-verify-ssl` flag is used. ([#445](https://github.com/peak/s5cmd/issues/445))
 
 ## v1.4.0 - 21 Sep 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed a bug where lines with large tokens fail in `run` command. `sync` was failing when it finds multiple files to remove. ([#435](https://github.com/peak/s5cmd/issues/435), [#436](https://github.com/peak/s5cmd/issues/436))
 - Print usage error if given log level(`--log`) is not valid. ([#430](https://github.com/peak/s5cmd/pull/430))
 - Fixed a bug where (`--stat`) is ignored when log level is error. ([#359](https://github.com/peak/s5cmd/issues/359))
+- Fixed a bug where proxy is not being used when `--no-verify-ssl` flag is used. ([#445](https://github.com/peak/s5cmd/issues/445))
 
 ## v1.4.0 - 21 Sep 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed a bug where lines with large tokens fail in `run` command. `sync` was failing when it finds multiple files to remove. ([#435](https://github.com/peak/s5cmd/issues/435), [#436](https://github.com/peak/s5cmd/issues/436))
 - Print usage error if given log level(`--log`) is not valid. ([#430](https://github.com/peak/s5cmd/pull/430))
 - Fixed a bug where (`--stat`) is ignored when log level is error. ([#359](https://github.com/peak/s5cmd/issues/359))
+- Fixed a bug where proxy is not being used when `--no-verify-ssl` flag is used. ([#445](https://github.com/peak/s5cmd/issues/445))
 
 ## v1.4.0 - 21 Sep 2021
 

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -148,7 +148,7 @@ func TestAppProxy(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			httpProxy, cleanupProxy := proxyFake(t)
+			httpProxy, cleanupProxy := proxyFake()
 			defer cleanupProxy()
 			os.Setenv("http_proxy", httpProxy)
 			_, s5cmd, cleanup := setup(t, withFakeProxy())

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -161,9 +161,9 @@ func TestAppProxy(t *testing.T) {
 			}
 			result := icmd.RunCmd(cmd)
 			result.Assert(t, icmd.Success)
-			assert.Assert(t, successfulRequests())
 		})
 	}
+	assert.Assert(t, successfulRequests(len(testcases)))
 }
 
 func TestAppUnknownCommand(t *testing.T) {

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -149,7 +150,7 @@ func TestAppProxy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			httpProxy, cleanupProxy := proxyFake(t)
 			defer cleanupProxy()
-			t.Setenv("http_proxy", httpProxy)
+			os.Setenv("http_proxy", httpProxy)
 			_, s5cmd, cleanup := setup(t, withFakeProxy())
 			defer cleanup()
 			var cmd icmd.Cmd

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -151,15 +151,15 @@ func TestAppProxy(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var totalReqs int64 = 1
+			const expectedReqs = 1
 
-			pxy := proxy{successReqs: 0, errorReqs: 0}
-			pxyUrl, cleanup := proxyFake(&pxy)
+			proxy := httpProxy{}
+			pxyUrl, cleanup := setupProxy(&proxy)
 			defer cleanup()
 
 			os.Setenv("http_proxy", pxyUrl)
 
-			_, s5cmd, cleanup := setup(t, withFakeProxy())
+			_, s5cmd, cleanup := setup(t, withProxy())
 			defer cleanup()
 
 			var cmd icmd.Cmd
@@ -172,7 +172,7 @@ func TestAppProxy(t *testing.T) {
 			result := icmd.RunCmd(cmd)
 
 			result.Assert(t, icmd.Success)
-			assert.Assert(t, pxy.isSuccessful(totalReqs))
+			assert.Assert(t, proxy.isSuccessful(expectedReqs))
 		})
 	}
 }

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -1,13 +1,12 @@
 package e2e
 
 import (
-	io "io"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"testing"
 )
 
 // Hop-by-hop headers. These are removed when sent to the backend.
@@ -104,7 +103,7 @@ func successfulRequests() bool {
 	}
 	return true
 }
-func proxyFake(t *testing.T) (string, func()) {
+func proxyFake() (string, func()) {
 	handler := &proxy{}
 	proxysrv := httptest.NewServer(handler)
 	cleanup := func() {

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -59,6 +59,9 @@ func (p *proxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		log.Println(msg)
 		return
 	}
+	//We need to explicitly set New Transport with no Proxy to make
+	//sure ServeHttp only receives the requests once. Otherwise, it
+	//causes proxy to call itself infinitely over and over again.
 	client := &http.Client{
 		Transport: &http.Transport{Proxy: nil},
 	}

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -80,7 +80,7 @@ func (p *proxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 		http.Error(wr, "Server Error", http.StatusInternalServerError)
 		log.Fatal("ServeHTTP:", err)
 	}
-	if resp.Status == "200 OK" {
+	if resp.StatusCode == http.StatusOK {
 		requests[req.RemoteAddr] = true
 	} else {
 		requests[req.RemoteAddr] = false

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -98,7 +98,7 @@ func successfulRequests() bool {
 		return false
 	}
 	for _, value := range requests {
-		if value != true {
+		if !value {
 			return false
 		}
 	}

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -1,0 +1,114 @@
+package e2e
+
+import (
+	io "io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Hop-by-hop headers. These are removed when sent to the backend.
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te", // canonicalized version of "TE"
+	"Trailers",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func delHopHeaders(header http.Header) {
+	for _, h := range hopHeaders {
+		header.Del(h)
+	}
+}
+
+func appendHostToXForwardHeader(header http.Header, host string) {
+	// If we aren't the first proxy retain prior
+	// X-Forwarded-For information as a comma+space
+	// separated list and fold multiple headers into one.
+	if prior, ok := header["X-Forwarded-For"]; ok {
+		host = strings.Join(prior, ", ") + ", " + host
+	}
+	header.Set("X-Forwarded-For", host)
+}
+
+type proxy struct {
+}
+
+var requests = make(map[string]bool)
+
+func (p *proxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
+	//log.Println(req.RemoteAddr, " ", req.Method, " ", req.URL)
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		msg := "unsupported protocol scheme " + req.URL.Scheme
+		http.Error(wr, msg, http.StatusBadRequest)
+		log.Println(msg)
+		return
+	}
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: nil},
+	}
+	//http: Request.RequestURI can't be set in client requests.
+	//http://golang.org/src/pkg/net/http/client.go
+	req.RequestURI = ""
+
+	delHopHeaders(req.Header)
+
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		appendHostToXForwardHeader(req.Header, clientIP)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(wr, "Server Error", http.StatusInternalServerError)
+		log.Fatal("ServeHTTP:", err)
+	}
+	if resp.Status == "200 OK" {
+		requests[req.RemoteAddr] = true
+	} else {
+		requests[req.RemoteAddr] = false
+	}
+	defer resp.Body.Close()
+
+	delHopHeaders(resp.Header)
+
+	copyHeader(wr.Header(), resp.Header)
+	wr.WriteHeader(resp.StatusCode)
+	io.Copy(wr, resp.Body)
+}
+
+// check if all requests got "200 OK" respond.
+func successfulRequests() bool {
+	if len(requests) == 0 {
+		return false
+	}
+	for _, value := range requests {
+		if value != true {
+			return false
+		}
+	}
+	return true
+}
+func proxyFake(t *testing.T) (string, func()) {
+	handler := &proxy{}
+	proxysrv := httptest.NewServer(handler)
+	cleanup := func() {
+		proxysrv.Close()
+	}
+	return proxysrv.URL, cleanup
+}

--- a/e2e/proxy_fake.go
+++ b/e2e/proxy_fake.go
@@ -94,9 +94,10 @@ func (p *proxy) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
 	io.Copy(wr, resp.Body)
 }
 
-// check if all requests got "200 OK" respond.
-func successfulRequests() bool {
-	if len(requests) == 0 {
+// check if all requests got "200 OK" respond and all
+// requests have passed through proxy
+func successfulRequests(totalRequest int) bool {
+	if len(requests) != totalRequest {
 		return false
 	}
 	for _, value := range requests {

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -61,10 +61,7 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 	if enableProxy {
 		splitURL := strings.Split(s3srv.URL, ":")
 		port := splitURL[2]
-		// "http://localhost.proxyman.io" is just a dns which points to localhost
-		// it is needed as some systems are hard to not use proxies for localhost traffic.
-		// another alternative workaround could be to use "http://localhost.charlesproxy.com"
-		proxyEnabledURL := "http://localhost.proxyman.io:" + port
+		proxyEnabledURL := "http://localhost.:" + port
 		return proxyEnabledURL, cleanup
 	}
 	return s3srv.URL, cleanup

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -59,8 +60,10 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 	}
 
 	if enableProxy {
-		splitURL := strings.Split(s3srv.URL, ":")
-		port := splitURL[2]
+		_, port, err := net.SplitHostPort(s3srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
 		proxyEnabledURL := "http://localhost.:" + port
 		return proxyEnabledURL, cleanup
 	}

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -60,7 +60,7 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 	}
 
 	if enableProxy {
-		parsedUrl, err := url.ParseRequestURI(s3srv.URL)
+		parsedUrl, err := url.Parse(s3srv.URL)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -11,7 +11,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, timeSource gofakes3.TimeSource) (string, func()) {
+func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, timeSource gofakes3.TimeSource, enableProxy bool) (string, func()) {
 	var s3backend gofakes3.Backend
 	switch backend {
 	case "mem":
@@ -58,5 +58,14 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 		// after each test.
 	}
 
+	if enableProxy {
+		splitURL := strings.Split(s3srv.URL, ":")
+		port := splitURL[2]
+		// "http://localhost.proxyman.io" is just a dns which points to localhost
+		// it is needed as some systems are hard to not use proxies for localhost traffic.
+		// another alternative workaround could be to use "http://localhost.charlesproxy.com"
+		proxyEnabledURL := "http://localhost.proxyman.io:" + port
+		return proxyEnabledURL, cleanup
+	}
 	return s3srv.URL, cleanup
 }

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -1,8 +1,8 @@
 package e2e
 
 import (
-	"net"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -60,11 +60,11 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 	}
 
 	if enableProxy {
-		_, port, err := net.SplitHostPort(s3srv.URL)
+		parsedUrl, err := url.ParseRequestURI(s3srv.URL)
 		if err != nil {
 			t.Fatal(err)
 		}
-		proxyEnabledURL := "http://localhost.:" + port
+		proxyEnabledURL := "http://localhost.:" + parsedUrl.Port()
 		return proxyEnabledURL, cleanup
 	}
 	return s3srv.URL, cleanup

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -60,6 +60,7 @@ type setupOpts struct {
 	s3backend   string
 	endpointURL string
 	timeSource  gofakes3.TimeSource
+	enableProxy bool
 }
 
 type option func(*setupOpts)
@@ -79,6 +80,12 @@ func withEndpointURL(url string) option {
 func withTimeSource(timeSource gofakes3.TimeSource) option {
 	return func(opts *setupOpts) {
 		opts.timeSource = timeSource
+	}
+}
+
+func withFakeProxy() option {
+	return func(opts *setupOpts) {
+		opts.enableProxy = true
 	}
 }
 
@@ -124,7 +131,7 @@ func server(t *testing.T, opts *setupOpts) (string, string, func()) {
 		s3LogLevel = "info" // aws has no level other than 'debug'
 	}
 
-	endpoint, dbcleanup := s3ServerEndpoint(t, testdir, s3LogLevel, opts.s3backend, opts.timeSource)
+	endpoint, dbcleanup := s3ServerEndpoint(t, testdir, s3LogLevel, opts.s3backend, opts.timeSource, opts.enableProxy)
 	if opts.endpointURL != "" {
 		endpoint = opts.endpointURL
 	}

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -83,7 +83,7 @@ func withTimeSource(timeSource gofakes3.TimeSource) option {
 	}
 }
 
-func withFakeProxy() option {
+func withProxy() option {
 	return func(opts *setupOpts) {
 		opts.enableProxy = true
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -927,6 +927,7 @@ func (c *customRetryer) ShouldRetry(req *request.Request) bool {
 var insecureHTTPClient = &http.Client{
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
 	},
 }
 


### PR DESCRIPTION
This change fixes the problem where proxy is ignored when no-verify-ssl flag is used.

- Test environment is created to test proxy support: proxy_fake.go is added.

Fixes #445