### PR TITLE
disable aws sdk logger if log level is not "trace"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## not released yet
 
+#### Improvements
+- disable aws sdk logger if log level is not "trace"
 
 ## v2.0.0 - 4 Jul 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## not released yet
 
 #### Improvements
-- disable aws sdk logger if log level is not "trace"
+- Disable AWS SDK logger if log level is not "trace"
 
 ## v2.0.0 - 4 Jul 2022
 

--- a/command/app.go
+++ b/command/app.go
@@ -162,6 +162,7 @@ func NewStorageOpts(c *cli.Context) storage.Options {
 		NoVerifySSL:      c.Bool("no-verify-ssl"),
 		RequestPayer:     c.String("request-payer"),
 		UseListObjectsV1: c.Bool("use-list-objects-v1"),
+		LogLevel:         c.String("log"),
 	}
 }
 

--- a/command/app.go
+++ b/command/app.go
@@ -162,7 +162,7 @@ func NewStorageOpts(c *cli.Context) storage.Options {
 		NoVerifySSL:      c.Bool("no-verify-ssl"),
 		RequestPayer:     c.String("request-payer"),
 		UseListObjectsV1: c.Bool("use-list-objects-v1"),
-		LogLevel:         c.String("log"),
+		LogLevel:         log.LevelFromString(c.String("log")),
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -24,28 +24,28 @@ func Init(level string, json bool) {
 
 // Trace prints message in trace mode.
 func Trace(msg Message) {
-	global.printf(levelTrace, msg, os.Stdout)
+	global.printf(LevelTrace, msg, os.Stdout)
 }
 
 // Debug prints message in debug mode.
 func Debug(msg Message) {
-	global.printf(levelDebug, msg, os.Stdout)
+	global.printf(LevelDebug, msg, os.Stdout)
 }
 
 // Info prints message in info mode.
 func Info(msg Message) {
-	global.printf(levelInfo, msg, os.Stdout)
+	global.printf(LevelInfo, msg, os.Stdout)
 }
 
 // Stat prints stat message regardless of the log level with info print formatting.
 // It uses printfHelper instead of printf to ignore the log level condition.
 func Stat(msg Message) {
-	global.printfHelper(levelInfo, msg, os.Stdout)
+	global.printfHelper(LevelInfo, msg, os.Stdout)
 }
 
 // Error prints message in error mode.
 func Error(msg Message) {
-	global.printf(levelError, msg, os.Stderr)
+	global.printf(LevelError, msg, os.Stderr)
 }
 
 // Close closes logger and its channel.
@@ -58,12 +58,12 @@ func Close() {
 type Logger struct {
 	donech chan struct{}
 	json   bool
-	level  logLevel
+	level  LogLevel
 }
 
 // New creates new logger.
 func New(level string, json bool) *Logger {
-	logLevel := levelFromString(level)
+	logLevel := LevelFromString(level)
 	logger := &Logger{
 		donech: make(chan struct{}),
 		json:   json,
@@ -74,14 +74,14 @@ func New(level string, json bool) *Logger {
 }
 
 // printf prints message according to the given level, message and std mode.
-func (l *Logger) printf(level logLevel, message Message, std *os.File) {
+func (l *Logger) printf(level LogLevel, message Message, std *os.File) {
 	if level < l.level {
 		return
 	}
 	l.printfHelper(level, message, std)
 }
 
-func (l *Logger) printfHelper(level logLevel, message Message, std *os.File) {
+func (l *Logger) printfHelper(level LogLevel, message Message, std *os.File) {
 	if l.json {
 		outputCh <- output{
 			message: message.JSON(),
@@ -104,26 +104,26 @@ func (l *Logger) out() {
 	}
 }
 
-// logLevel is the level of Logger.
-type logLevel int
+// LogLevel is the level of Logger.
+type LogLevel int
 
 const (
-	levelTrace logLevel = iota
-	levelDebug
-	levelInfo
-	levelError
+	LevelTrace LogLevel = iota
+	LevelDebug
+	LevelInfo
+	LevelError
 )
 
 // String returns the string representation of logLevel.
-func (l logLevel) String() string {
+func (l LogLevel) String() string {
 	switch l {
-	case levelInfo:
+	case LevelInfo:
 		return ""
-	case levelError:
+	case LevelError:
 		return "ERROR "
-	case levelDebug:
+	case LevelDebug:
 		return "DEBUG "
-	case levelTrace:
+	case LevelTrace:
 		// levelTrace is used for printing aws sdk logs and
 		// aws-sdk-go already adds "DEBUG" prefix to logs.
 		// So do not add another prefix to log which makes it
@@ -134,19 +134,19 @@ func (l logLevel) String() string {
 	}
 }
 
-// levelFromString returns logLevel for given string. It
+// LevelFromString returns logLevel for given string. It
 // return `levelInfo` as a default.
-func levelFromString(s string) logLevel {
+func LevelFromString(s string) LogLevel {
 	switch s {
 	case "debug":
-		return levelDebug
+		return LevelDebug
 	case "info":
-		return levelInfo
+		return LevelInfo
 	case "error":
-		return levelError
+		return LevelError
 	case "trace":
-		return levelTrace
+		return LevelTrace
 	default:
-		return levelInfo
+		return LevelInfo
 	}
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -801,7 +801,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithS3UseAccelerate(useAccelerate).
 		WithHTTPClient(httpClient)
 
-	if opts.LogLevel == "trace" {
+	if log.LevelFromString(opts.LogLevel) != log.LevelTrace {
 		awsCfg = awsCfg.WithLogLevel(aws.LogDebug).
 			WithLogger(sdkLogger{})
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -801,7 +801,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithS3UseAccelerate(useAccelerate).
 		WithHTTPClient(httpClient)
 
-	if log.LevelFromString(opts.LogLevel) != log.LevelTrace {
+	if log.LevelFromString(opts.LogLevel) == log.LevelTrace {
 		awsCfg = awsCfg.WithLogLevel(aws.LogDebug).
 			WithLogger(sdkLogger{})
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -801,7 +801,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithS3UseAccelerate(useAccelerate).
 		WithHTTPClient(httpClient)
 
-	if log.LevelFromString(opts.LogLevel) == log.LevelTrace {
+	if opts.LogLevel == log.LevelTrace {
 		awsCfg = awsCfg.WithLogLevel(aws.LogDebug).
 			WithLogger(sdkLogger{})
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -799,9 +799,12 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 		WithEndpoint(endpointURL.String()).
 		WithS3ForcePathStyle(!isVirtualHostStyle).
 		WithS3UseAccelerate(useAccelerate).
-		WithHTTPClient(httpClient).
-		WithLogLevel(aws.LogDebug).
-		WithLogger(sdkLogger{})
+		WithHTTPClient(httpClient)
+
+	if opts.LogLevel == "trace" {
+		awsCfg = awsCfg.WithLogLevel(aws.LogDebug).
+			WithLogger(sdkLogger{})
+	}
 
 	awsCfg.Retryer = newCustomRetryer(opts.MaxRetries)
 

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -1068,7 +1068,7 @@ func TestAWSLogLevel(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			globalSessionCache.clear()
 			sess, err := globalSessionCache.newSession(context.Background(), Options{
-				LogLevel: tc.level,
+				LogLevel: log.LevelFromString(tc.level),
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -1036,6 +1036,52 @@ func TestS3ListObjectsAPIVersions(t *testing.T) {
 	})
 }
 
+func TestAWSLogLevel(t *testing.T) {
+	testcases := []struct {
+		name     string
+		level    string
+		expected aws.LogLevelType
+	}{
+		{
+			name:     "Trace: log level must be aws.LogDebug",
+			level:    "trace",
+			expected: aws.LogDebug,
+		},
+		{
+			name:     "Debug: log level must be aws.LogOff",
+			level:    "debug",
+			expected: aws.LogOff,
+		},
+		{
+			name:     "Info: log level must be aws.LogOff",
+			level:    "info",
+			expected: aws.LogOff,
+		},
+		{
+			name:     "Error: log level must be aws.LogOff",
+			level:    "error",
+			expected: aws.LogOff,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			globalSessionCache.clear()
+			sess, err := globalSessionCache.newSession(context.Background(), Options{
+				LogLevel: tc.level,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cfgLogLevel := *sess.Config.LogLevel
+			if diff := cmp.Diff(cfgLogLevel, tc.expected); diff != "" {
+				t.Errorf("%s: (-want +got):\n%v", tc.name, diff)
+			}
+		})
+	}
+}
+
 func valueAtPath(i interface{}, s string) interface{} {
 	v, err := awsutil.ValuesAtPath(i, s)
 	if err != nil || len(v) == 0 {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/peak/s5cmd/log"
 	"github.com/peak/s5cmd/storage/url"
 	"github.com/peak/s5cmd/strutil"
 )
@@ -77,8 +78,8 @@ type Options struct {
 	DryRun           bool
 	NoSignRequest    bool
 	UseListObjectsV1 bool
+	LogLevel         log.LogLevel
 	RequestPayer     string
-	LogLevel         string
 	bucket           string
 	region           string
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -55,6 +55,7 @@ func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, erro
 		NoSignRequest:    opts.NoSignRequest,
 		UseListObjectsV1: opts.UseListObjectsV1,
 		RequestPayer:     opts.RequestPayer,
+		LogLevel:         opts.LogLevel,
 		bucket:           url.Bucket,
 		region:           opts.region,
 	}
@@ -77,6 +78,7 @@ type Options struct {
 	NoSignRequest    bool
 	UseListObjectsV1 bool
 	RequestPayer     string
+	LogLevel         string
 	bucket           string
 	region           string
 }


### PR DESCRIPTION
Currently, we request aws-sdk's logs regardless of s5cmd's log level, then we either use or discard those logs depending on the log level.

This commit disables aws-sdk logs (unless log level is "trace") instead of discarding the logs after they created.

So, it will reduce the memory/CPU usage when other log levels used, since those unneeded logs won't be created at all.