### PR TITLE
Change cp error not being descriptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## not released yet
 
+#### Bugfixes
+
+- Changed cp error message to be more precise. "given object not found" error message now will also include absolute path of the file. ([#463](https://github.com/peak/s5cmd/pull/463))
+
 
 ## v2.0.0 - 4 Jul 2022
 

--- a/command/cp.go
+++ b/command/cp.go
@@ -752,8 +752,8 @@ func prepareLocalDestination(
 	obj, err := client.Stat(ctx, dsturl)
 
 	if err != nil {
-		var givenObjNotFoundErr *storage.ErrGivenObjectNotFound
-		if !errors.As(err, &givenObjNotFoundErr) {
+		var objNotFound *storage.ErrGivenObjectNotFound
+		if !errors.As(err, &objNotFound) {
 			return nil, err
 		}
 	}
@@ -765,8 +765,8 @@ func prepareLocalDestination(
 			return nil, err
 		}
 	}
-	var givenObjNotFoundErr *storage.ErrGivenObjectNotFound
-	if errors.As(err, &givenObjNotFoundErr) {
+	var objNotFound *storage.ErrGivenObjectNotFound
+	if errors.As(err, &objNotFound) {
 		err := client.MkdirAll(dsturl.Dir())
 		if err != nil {
 			return nil, err
@@ -787,8 +787,8 @@ func prepareLocalDestination(
 // found, error and returning object would be nil.
 func getObject(ctx context.Context, url *url.URL, client storage.Storage) (*storage.Object, error) {
 	obj, err := client.Stat(ctx, url)
-	var givenObjNotFoundErr *storage.ErrGivenObjectNotFound
-	if errors.As(err, &givenObjNotFoundErr) {
+	var objNotFound *storage.ErrGivenObjectNotFound
+	if errors.As(err, &objNotFound) {
 		return nil, nil
 	}
 

--- a/command/expand.go
+++ b/command/expand.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/peak/s5cmd/atomic"
@@ -68,7 +69,8 @@ func expandSources(
 
 				objch, err := expandSource(ctx, client, followSymlinks, origSrc)
 				if err != nil {
-					if err != storage.ErrGivenObjectNotFound {
+					var givenObjNotFoundErr *storage.ErrGivenObjectNotFound
+					if !errors.As(err, &givenObjNotFoundErr) {
 						ch <- &storage.Object{Err: err}
 					}
 					return

--- a/command/expand.go
+++ b/command/expand.go
@@ -69,8 +69,8 @@ func expandSources(
 
 				objch, err := expandSource(ctx, client, followSymlinks, origSrc)
 				if err != nil {
-					var givenObjNotFoundErr *storage.ErrGivenObjectNotFound
-					if !errors.As(err, &givenObjNotFoundErr) {
+					var objNotFound *storage.ErrGivenObjectNotFound
+					if !errors.As(err, &objNotFound) {
 						ch <- &storage.Object{Err: err}
 					}
 					return

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -2829,7 +2829,7 @@ func TestCopyErrorWhenGivenObjectIsNotFoundUsingWildcard(t *testing.T) {
 	result.Assert(t, icmd.Expected{ExitCode: 1})
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
-		0: equals(`ERROR "cp * %v": given b/link1 not found`, dst),
+		0: equals(`ERROR "cp * %v": given object b/link1 not found`, dst),
 	}, sortInput(true))
 }
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -2812,8 +2812,8 @@ func TestCopyErrorWhenGivenObjectIsNotFoundUsingWildcard(t *testing.T) {
 	createBucket(t, s3client, bucket)
 
 	folderLayout := []fs.PathOp{
-		//we intentionally did not create a/f1.txt to
-		//trigger given object not found error.
+		// we intentionally did not create a/f1.txt to
+		// trigger given object not found error.
 		fs.WithDir("b"),
 		fs.WithSymlink("b/link1", "a/f1.txt"),
 	}

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -2802,6 +2802,37 @@ func TestCopyWithFollowSymlink(t *testing.T) {
 	assert.Assert(t, ensureS3Object(s3client, bucket, "prefix/c/link2", fileContent))
 }
 
+func TestCopyErrorWhenGivenObjectIsNotFoundUsingWildcard(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd, cleanup := setup(t)
+	defer cleanup()
+
+	const bucket = "bucket"
+	createBucket(t, s3client, bucket)
+
+	folderLayout := []fs.PathOp{
+		//we intentionally did not create a/f1.txt to
+		//trigger given object not found error.
+		fs.WithDir("b"),
+		fs.WithSymlink("b/link1", "a/f1.txt"),
+	}
+
+	workdir := fs.NewDir(t, t.Name(), folderLayout...)
+	defer workdir.Remove()
+
+	dst := fmt.Sprintf("s3://%v/prefix/", bucket)
+
+	cmd := s5cmd("cp", "*", dst)
+	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+
+	assertLines(t, result.Stderr(), map[int]compareFunc{
+		0: equals(`ERROR "cp * %v": given b/link1 not found`, dst),
+	}, sortInput(true))
+}
+
 // cp --no-follow-symlinks * s3://bucket/prefix/
 func TestCopyWithNoFollowSymlink(t *testing.T) {
 	t.Parallel()

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -98,7 +98,7 @@ func TestRunFromStdinWithErrors(t *testing.T) {
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
 		0: contains(`ERROR "cp s3://%v/nonexistentobject nonexistentobject": NoSuchKey: status code: 404`, bucket),
-		1: equals(`ERROR "ls s3/": given s3/ not found`),
+		1: equals(`ERROR "ls s3/": given object s3/ not found`),
 	}, sortInput(true))
 }
 

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -98,7 +98,7 @@ func TestRunFromStdinWithErrors(t *testing.T) {
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
 		0: contains(`ERROR "cp s3://%v/nonexistentobject nonexistentobject": NoSuchKey: status code: 404`, bucket),
-		1: equals(`ERROR "ls s3/": given object not found`),
+		1: equals(`ERROR "ls s3/": given s3/ not found`),
 	}, sortInput(true))
 }
 

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -22,7 +22,7 @@ func (f *Filesystem) Stat(ctx context.Context, url *url.URL) (*Object, error) {
 	st, err := os.Stat(url.Absolute())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, ErrGivenObjectNotFound
+			return nil, &ErrGivenObjectNotFound{ObjectAbsPath: url.Absolute()}
 		}
 		return nil, err
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -118,7 +118,7 @@ func (s *S3) Stat(ctx context.Context, url *url.URL) (*Object, error) {
 	})
 	if err != nil {
 		if errHasCode(err, "NotFound") {
-			return nil, ErrGivenObjectNotFound
+			return nil, &ErrGivenObjectNotFound{ObjectAbsPath: url.Absolute()}
 		}
 		return nil, err
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -24,7 +24,7 @@ type ErrGivenObjectNotFound struct {
 }
 
 func (e *ErrGivenObjectNotFound) Error() string {
-	return fmt.Sprintf("given %v not found", e.ObjectAbsPath)
+	return fmt.Sprintf("given object %v not found", e.ObjectAbsPath)
 }
 
 // Storage is an interface for storage operations that is common

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -13,12 +13,19 @@ import (
 )
 
 var (
-	// ErrGivenObjectNotFound indicates a specified object is not found.
-	ErrGivenObjectNotFound = fmt.Errorf("given object not found")
 
 	// ErrNoObjectFound indicates there are no objects found from a given directory.
 	ErrNoObjectFound = fmt.Errorf("no object found")
 )
+
+// ErrGivenObjectNotFound indicates a specified object is not found.
+type ErrGivenObjectNotFound struct {
+	ObjectAbsPath string
+}
+
+func (e *ErrGivenObjectNotFound) Error() string {
+	return fmt.Sprintf("given %v not found", e.ObjectAbsPath)
+}
 
 // Storage is an interface for storage operations that is common
 // to local filesystem and remote object storage.


### PR DESCRIPTION
With this fix, when "given object not found" error message will also include absolute path of the file.

Fixes https://github.com/peak/s5cmd/issues/461