### PR TITLE
Make it possible to override content-type and content-encoding from CLI arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## not released yet
 
+#### Features
+- Added `--content-type` and `--content-encoding` flags to `cp` command. ([#264](https://github.com/peak/s5cmd/issues/264))
 
 ## v2.0.0 - 4 Jul 2022
 

--- a/command/cp.go
+++ b/command/cp.go
@@ -561,7 +561,6 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) er
 	}
 
 	metadata := storage.NewMetadata().
-		SetContentType(guessContentType(file)).
 		SetStorageClass(string(c.storageClass)).
 		SetSSE(c.encryptionMethod).
 		SetSSEKeyID(c.encryptionKeyID).
@@ -571,7 +570,10 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) er
 
 	if c.contentType != "" {
 		metadata.SetContentType(c.contentType)
+	} else {
+		metadata.SetContentType(guessContentType(file))
 	}
+
 	if c.contentEncoding != "" {
 		metadata.SetContentEncoding(c.contentEncoding)
 	}

--- a/command/cp.go
+++ b/command/cp.go
@@ -98,6 +98,9 @@ Examples:
 
 	20. Download an S3 object from a requester pays bucket
 		 > s5cmd --request-payer=requester {{.HelpName}} s3://bucket/prefix/object.gz .
+
+	21. Upload a file to S3 with a content-type and content-encoding header
+		 > s5cmd --content-type "text/css" --content-encoding "br" myfile.css.br s3://bucket/
 `
 
 func NewSharedFlags() []cli.Flag {

--- a/command/cp.go
+++ b/command/cp.go
@@ -165,6 +165,14 @@ func NewSharedFlags() []cli.Flag {
 			Name:  "raw",
 			Usage: "disable the wildcard operations, useful with filenames that contains glob characters",
 		},
+		&cli.StringFlag{
+			Name:  "content-type",
+			Usage: "set content type for target: defines content type header for object, e.g. --content-type text/plain",
+		},
+		&cli.StringFlag{
+			Name:  "content-encoding",
+			Usage: "set content encoding for target: defines content encoding header for object, e.g. --content-encoding gzip",
+		},
 	}
 }
 
@@ -243,6 +251,8 @@ type Copy struct {
 	raw                   bool
 	cacheControl          string
 	expires               string
+	contentType           string
+	contentEncoding       string
 
 	// region settings
 	srcRegion string
@@ -280,6 +290,8 @@ func NewCopy(c *cli.Context, deleteSource bool) Copy {
 		raw:                   c.Bool("raw"),
 		cacheControl:          c.String("cache-control"),
 		expires:               c.String("expires"),
+		contentType:           c.String("content-type"),
+		contentEncoding:       c.String("content-encoding"),
 		// region settings
 		srcRegion: c.String("source-region"),
 		dstRegion: c.String("destination-region"),
@@ -557,6 +569,13 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) er
 		SetCacheControl(c.cacheControl).
 		SetExpires(c.expires)
 
+	if c.contentType != "" {
+		metadata.SetContentType(c.contentType)
+	}
+	if c.contentEncoding != "" {
+		metadata.SetContentEncoding(c.contentEncoding)
+	}
+
 	err = dstClient.Put(ctx, file, dsturl, metadata, c.concurrency, c.partSize)
 	if err != nil {
 		return err
@@ -604,6 +623,13 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL) error {
 		SetACL(c.acl).
 		SetCacheControl(c.cacheControl).
 		SetExpires(c.expires)
+
+	if c.contentType != "" {
+		metadata.SetContentType(c.contentType)
+	}
+	if c.contentEncoding != "" {
+		metadata.SetContentEncoding(c.contentEncoding)
+	}
 
 	err = c.shouldOverride(ctx, srcurl, dsturl)
 	if err != nil {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -549,6 +549,11 @@ func (s *S3) Put(
 		}
 	}
 
+	contentEncoding := metadata.ContentEncoding()
+	if contentEncoding != "" {
+		input.ContentEncoding = aws.String(contentEncoding)
+	}
+
 	_, err := s.uploader.UploadWithContext(ctx, input, func(u *s3manager.Uploader) {
 		u.PartSize = partSize
 		u.Concurrency = concurrency

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -265,3 +265,12 @@ func (m Metadata) SetSSEKeyID(kid string) Metadata {
 	m["EncryptionKeyID"] = kid
 	return m
 }
+
+func (m Metadata) ContentEncoding() string {
+	return m["ContentEncoding"]
+}
+
+func (m Metadata) SetContentEncoding(contentEncoding string) Metadata {
+	m["ContentEncoding"] = contentEncoding
+	return m
+}


### PR DESCRIPTION
This PR lets users override Content-Type and Content-Encoding headers, to close #264. #318 is a similar PR which added the --cache-control and --expires options.