### PR TITLE
vendor: upgrade gofakes3 to v0.0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         os:
           - macos
           - ubuntu
+          - windows
 
     name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}-latest
@@ -44,27 +45,6 @@ jobs:
 
     - run: make test
     
-  test_windows:
-    strategy:
-      matrix:
-        go-version:
-          - 1.18.x
-          - 1.17.x
-          - 1.16.x
-        os:
-          - windows
-
-    name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
-    runs-on: ${{ matrix.os }}-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-
-    # tests fail in windows if the race flag is used
-    - run: make test_without_race
-
   qa:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
         os:
           - macos
           - ubuntu
-          - windows
 
     name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}-latest
@@ -44,6 +43,27 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - run: make test
+    
+  test_windows:
+    strategy:
+      matrix:
+        go-version:
+          - 1.18.x
+          - 1.17.x
+          - 1.16.x
+        os:
+          - windows
+
+    name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    # tests fail in windows if the race flag is used
+    - run: make test_without_race
 
   qa:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - run: make test
-    
+
   qa:
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,21 @@ LDFLAGS=-ldflags "-X=github.com/peak/s5cmd/version.Version=$(VERSION) -X=github.
 build:
 	@go build ${GCFLAGS} ${LDFLAGS} -mod=vendor .
 
-RACE_FLAG := -race
+TEST_TYPE:=test_with_race
 ifeq ($(OS),Windows_NT)
-	RACE_FLAG =
+	TEST_TYPE=test_without_race
 endif
 
 .PHONY: test
-test:
-	@S5CMD_TEST_DISABLE_RACE=0 go test -mod=vendor -count=1 ${RACE_FLAG} ./...
+test: $(TEST_TYPE)
 
+.PHONY: test_with_race
+test_with_race:
+	@S5CMD_TEST_DISABLE_RACE=0 go test -mod=vendor -count=1 -race ./...
+
+.PHONY: test_without_race
 test_without_race:
-	@S5CMD_TEST_DISABLE_RACE=1 go test -mod=vendor -count=1 ${RACE_FLAG} ./...
+	@S5CMD_TEST_DISABLE_RACE=1 go test -mod=vendor -count=1 ./...
 
 .PHONY: check
 check: vet staticcheck unparam check-fmt

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ endif
 
 .PHONY: test
 test:
-	@go test -mod=vendor -count=1 ${RACE_FLAG} ./...
+	@S5CMD_TEST_DISABLE_RACE=0 go test -mod=vendor -count=1 ${RACE_FLAG} ./...
+
+test_without_race:
+	@S5CMD_TEST_DISABLE_RACE=1 go test -mod=vendor -count=1 ${RACE_FLAG} ./...
 
 .PHONY: check
 check: vet staticcheck unparam check-fmt

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ test: $(TEST_TYPE)
 
 .PHONY: test_with_race
 test_with_race:
-	@S5CMD_TEST_DISABLE_RACE=0 go test -mod=vendor -count=1 -race ./...
+	@S5CMD_BUILD_BINARY_WITHOUT_RACE_FLAG=0 go test -mod=vendor -count=1 -race ./...
 
 .PHONY: test_without_race
 test_without_race:
-	@S5CMD_TEST_DISABLE_RACE=1 go test -mod=vendor -count=1 ./...
+	@S5CMD_BUILD_BINARY_WITHOUT_RACE_FLAG=1 go test -mod=vendor -count=1 ./...
 
 .PHONY: check
 check: vet staticcheck unparam check-fmt

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if !flag.Parsed() {
-		flag.Parse()
-	}
+	flag.Parse()
 
 	cleanup := goBuildS5cmd()
 	code := m.Run()

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,11 +1,16 @@
 package e2e
 
 import (
+	"flag"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
 	cleanup := goBuildS5cmd()
 	code := m.Run()
 	cleanup()

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -40,8 +40,8 @@ import (
 
 const (
 	// Don't use "race" flag in the build arguments.
-	TEST_DISABLE_RACE_FLAG_KEY   = "S5CMD_TEST_DISABLE_RACE"
-	TEST_DISABLE_RACE_FLAG_VALUE = "1"
+	testDisableRaceFlagKey = "S5CMD_BUILD_BINARY_WITHOUT_RACE_FLAG"
+	testDisableRaceFlagVal = "1"
 )
 
 var (
@@ -217,7 +217,7 @@ func goBuildS5cmd() func() {
 
 	var args []string
 
-	if os.Getenv(TEST_DISABLE_RACE_FLAG_KEY) == TEST_DISABLE_RACE_FLAG_VALUE {
+	if os.Getenv(testDisableRaceFlagKey) == testDisableRaceFlagVal {
 		/*
 		 1. disable '-race' flag because CI fails with below error.
 

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -38,6 +38,12 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
+const (
+	// Don't use "race" flag in the build arguments.
+	TEST_DISABLE_RACE_FLAG_KEY   = "S5CMD_TEST_DISABLE_RACE"
+	TEST_DISABLE_RACE_FLAG_VALUE = "1"
+)
+
 var (
 	defaultAccessKeyID     = "s5cmd-test-access-key-id"
 	defaultSecretAccessKey = "s5cmd-test-secret-access-key"
@@ -48,9 +54,8 @@ var (
 var dateRe = `(\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2})`
 
 var (
-	flagTestLogLevel     = flag.String("test.log.level", "err", "Test log level: {debug|warn|err}")
-	flagTestRaceDisabled = flag.Bool("test.race.disabled", false, `Don't use "race" flag in the build arguments.`)
-	s5cmdPath            string
+	flagTestLogLevel = flag.String("test.log.level", "err", "Test log level: {debug|warn|err}")
+	s5cmdPath        string
 )
 
 func init() {
@@ -211,7 +216,8 @@ func goBuildS5cmd() func() {
 	workdir = filepath.Dir(workdir)
 
 	var args []string
-	if runtime.GOOS == "windows" || *flagTestRaceDisabled {
+
+	if os.Getenv(TEST_DISABLE_RACE_FLAG_KEY) == TEST_DISABLE_RACE_FLAG_VALUE {
 		/*
 		 1. disable '-race' flag because CI fails with below error.
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
-	github.com/igungor/gofakes3 v0.0.10
+	github.com/igungor/gofakes3 v0.0.11
 	github.com/karrick/godirwalk v1.15.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
-github.com/igungor/gofakes3 v0.0.10 h1:/sGbnHRjqYyK3iRQ8jOFZQhsxTMOYLCk7+CVN3FPYF4=
-github.com/igungor/gofakes3 v0.0.10/go.mod h1:id+2y7yvTVoN1HW6VOtnfSqFt4EAfH5piVL4p9JsmQc=
+github.com/igungor/gofakes3 v0.0.11 h1:KqVnxdhlrc5LQYUBifexI/E0X7V5CUonTmvfujkmKao=
+github.com/igungor/gofakes3 v0.0.11/go.mod h1:id+2y7yvTVoN1HW6VOtnfSqFt4EAfH5piVL4p9JsmQc=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/vendor/github.com/igungor/gofakes3/gofakes3.go
+++ b/vendor/github.com/igungor/gofakes3/gofakes3.go
@@ -23,6 +23,8 @@ import (
 //
 // Logic is delegated to other components, like Backend or uploader.
 type GoFakeS3 struct {
+	requestID uint64
+
 	storage   Backend
 	versioned VersionedBackend
 
@@ -33,7 +35,6 @@ type GoFakeS3 struct {
 	failOnUnimplementedPage bool
 	hostBucket              bool
 	uploader                *uploader
-	requestID               uint64
 	log                     Logger
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/hashicorp/errwrap
 github.com/hashicorp/go-multierror
 # github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 github.com/iancoleman/strcase
-# github.com/igungor/gofakes3 v0.0.10
+# github.com/igungor/gofakes3 v0.0.11
 github.com/igungor/gofakes3
 github.com/igungor/gofakes3/backend/s3bolt
 github.com/igungor/gofakes3/backend/s3mem


### PR DESCRIPTION
Upgraded gofakes version to v0.0.11 to solve unaligned bit error in 32 bit architectures.
Allow disabling race flag (race flag is incompatible with `-buildmode=pie`)

Fixes #446