### PR TITLE
e2e: refactor cleanup behavior using t.Cleanup

### DIFF
--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -45,8 +45,7 @@ func TestAppRetryCount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			_, s5cmd := setup(t)
 
 			cmd := s5cmd("-r", strconv.Itoa(tc.retry))
 			result := icmd.RunCmd(cmd)
@@ -117,8 +116,7 @@ func TestAppDashStat(t *testing.T) {
 		tc := tc
 		t.Run(tc.command, func(t *testing.T) {
 			t.Parallel()
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 			putFile(t, s3client, bucket, src, fileContent)
@@ -154,13 +152,11 @@ func TestAppProxy(t *testing.T) {
 			const expectedReqs = 1
 
 			proxy := httpProxy{}
-			pxyUrl, cleanup := setupProxy(&proxy)
-			defer cleanup()
+			pxyUrl := setupProxy(t, &proxy)
 
 			os.Setenv("http_proxy", pxyUrl)
 
-			_, s5cmd, cleanup := setup(t, withProxy())
-			defer cleanup()
+			_, s5cmd := setup(t, withProxy())
 
 			var cmd icmd.Cmd
 			if tc.flag != "" {
@@ -180,8 +176,7 @@ func TestAppProxy(t *testing.T) {
 func TestAppUnknownCommand(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("unknown-command")
 	result := icmd.RunCmd(cmd)
@@ -196,8 +191,7 @@ func TestAppUnknownCommand(t *testing.T) {
 func TestUsageError(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("--recursive", "ls")
 	result := icmd.RunCmd(cmd)
@@ -214,8 +208,7 @@ func TestUsageError(t *testing.T) {
 func TestInvalidLoglevel(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("--log", "notexist", "ls")
 	result := icmd.RunCmd(cmd)

--- a/e2e/cat_test.go
+++ b/e2e/cat_test.go
@@ -51,8 +51,7 @@ func TestCatS3Object(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 			putFile(t, s3client, bucket, filename, contents)
@@ -140,8 +139,7 @@ func TestCatS3ObjectFail(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -193,8 +191,7 @@ func TestCatLocalFileFail(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			_, s5cmd := setup(t)
 
 			cmd := s5cmd(tc.cmd...)
 			result := icmd.RunCmd(cmd)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -114,8 +114,7 @@ func TestCopySingleS3ObjectToLocal(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -147,8 +146,7 @@ func TestCopySingleS3ObjectToLocalJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -195,8 +193,7 @@ func TestCopySingleS3ObjectToLocalWithDestinationWildcard(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -231,8 +228,7 @@ func TestCopyS3PrefixToLocalMustReturnError(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -268,8 +264,7 @@ func TestCopyMultipleFlatS3ObjectsToLocal(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -319,8 +314,7 @@ func TestCopyMultipleFlatS3ObjectsToLocalWithPartialMatching(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -365,8 +359,7 @@ func TestCopyMultipleFlatNestedS3ObjectsToLocalWithPartialMatching(t *testing.T)
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -405,8 +398,7 @@ func TestCopyMultipleFlatS3ObjectsToLocalJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -500,8 +492,7 @@ func TestCopyMultipleNestedS3ObjectsToLocal(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -571,8 +562,7 @@ func TestCopyMultipleNestedS3ObjectsToLocalWithPartial(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -631,8 +621,7 @@ func TestCopyMultipleS3ObjectsToGivenLocalDirectory(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -688,8 +677,7 @@ func TestCopySingleFileToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -784,8 +772,7 @@ func TestCopySingleFileToS3WithAdjacentSlashes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -820,8 +807,7 @@ func TestCopySingleFileToS3JSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -871,8 +857,7 @@ func TestCopyDirToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -923,8 +908,7 @@ func TestCopyDirBackslashedToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -966,8 +950,7 @@ func TestCopySingleFileToS3WithStorageClassGlacier(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1008,8 +991,7 @@ func TestFlattenCopyDirToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1057,8 +1039,7 @@ func TestCopyMultipleFilesToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1115,8 +1096,7 @@ func TestCopyMultipleFilesWithWildcardedDirectoryToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1168,8 +1148,7 @@ func TestCopyMultipleFilesEndWildcardedToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1221,8 +1200,7 @@ func TestCopyMultipleFilesMiddleWildcardedDirectoryToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1267,8 +1245,7 @@ func TestFlattenCopyMultipleFilesToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1326,8 +1303,7 @@ func TestCopyMultipleFilesToS3WithPrefixWithoutSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1375,8 +1351,7 @@ func TestCopyDirectoryWithGlobCharactersToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1427,8 +1402,7 @@ func TestCopyMultipleFilesToS3WithPrefixWithSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1489,8 +1463,7 @@ func TestFlattenCopyMultipleFilesToS3WithPrefixWithSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1551,8 +1524,7 @@ func TestCopyLocalDirectoryToS3WithPrefixWithSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1611,8 +1583,7 @@ func TestFlattenCopyLocalDirectoryToS3WithPrefixWithSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1674,8 +1645,7 @@ func TestCopyLocalDirectoryToS3WithPrefixWithoutSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1719,8 +1689,7 @@ func TestCopySingleS3ObjectToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1757,8 +1726,7 @@ func TestCopySingleS3ObjectToS3JSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1809,8 +1777,7 @@ func TestCopySingleS3ObjectIntoAnotherBucket(t *testing.T) {
 	srcbucket := s3BucketFromTestName(t)
 	dstbucket := "copy-" + s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -1848,8 +1815,7 @@ func TestFlattenCopySingleS3ObjectIntoAnotherBucket(t *testing.T) {
 	srcbucket := s3BucketFromTestName(t)
 	dstbucket := "copy-" + s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -1889,8 +1855,7 @@ func TestCopySingleS3ObjectIntoAnotherBucketWithObjName(t *testing.T) {
 		dstbucket = "dstbucket"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -1927,8 +1892,7 @@ func TestCopySingleS3ObjectIntoAnotherBucketWithPrefix(t *testing.T) {
 
 	const bucket = "bucket"
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -1967,8 +1931,7 @@ func TestCopyAllObjectsIntoAnotherBucketIncludingSpecialCharacter(t *testing.T) 
 		dstbucket = "dstbucket"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -2007,8 +1970,7 @@ func TestCopyMultipleS3ObjectsToS3WithPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2055,8 +2017,7 @@ func TestFlattenCopyMultipleS3ObjectsToS3WithPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2110,8 +2071,7 @@ func TestCopyMultipleS3ObjectsToS3WithPrefixWithoutSlash(t *testing.T) {
 
 	const bucket = "bucket"
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2151,8 +2111,7 @@ func TestCopyMultipleS3ObjectsToS3JSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2217,8 +2176,7 @@ func TestCopyMultipleS3ObjectsToS3_Issue70(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2260,8 +2218,7 @@ func TestCopyS3ObjectToLocalWithTheSameFilename(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2295,8 +2252,7 @@ func TestCopyS3ToLocalWithSameFilenameWithNoClobber(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -2331,8 +2287,7 @@ func TestCopyS3ToLocalWithSameFilenameOverrideIfSizeDiffers(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2368,8 +2323,7 @@ func TestCopyS3ToLocalWithSameFilenameOverrideIfSourceIsNewer(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2411,8 +2365,7 @@ func TestCopyS3ToLocalWithSameFilenameDontOverrideIfS3ObjectIsOlder(t *testing.T
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -2456,8 +2409,7 @@ func TestCopyS3ToLocal_Issue70(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -2513,8 +2465,7 @@ func TestCopyLocalFileToS3WithTheSameFilename(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename   = "testfile1.txt"
@@ -2553,8 +2504,7 @@ func TestCopyLocalFileToS3WithSameFilenameWithNoClobber(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename   = "testfile1.txt"
@@ -2594,8 +2544,7 @@ func TestCopyLocalFileToS3WithNoClobber(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename   = "testfile1.txt"
@@ -2635,8 +2584,7 @@ func TestCopyLocalFileToS3WithSameFilenameOverrideIfSizeDiffers(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2674,8 +2622,7 @@ func TestCopyLocalFileToS3WithSameFilenameOverrideIfSourceIsNewer(t *testing.T) 
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2719,8 +2666,7 @@ func TestCopyLocalFileToS3WithSameFilenameDontOverrideIfS3ObjectIsOlder(t *testi
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename        = "testfile1.txt"
@@ -2771,8 +2717,7 @@ func TestCopyLocalFileToS3WithFilePermissions(t *testing.T) {
 	fileModes := []os.FileMode{0400, 0440, 0444, 0600, 0640, 0644, 0700, 0750, 0755}
 
 	for _, fileMode := range fileModes {
-		s3client, s5cmd, cleanup := setup(t)
-		defer cleanup()
+		s3client, s5cmd := setup(t)
 
 		createBucket(t, s3client, bucket)
 
@@ -2805,8 +2750,7 @@ func TestCopyLocalFileToS3WithCustomName(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -2843,8 +2787,7 @@ func TestCopyLocalFileToS3WithPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -2881,8 +2824,7 @@ func TestMultipleLocalFileToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -2917,8 +2859,7 @@ func TestMultipleLocalFileToS3Bucket(t *testing.T) {
 func TestCopyMultipleLocalNestedFilesToS3(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -2987,8 +2928,7 @@ func TestCopyMultipleLocalNestedFilesToS3(t *testing.T) {
 func TestCopyLinkToASingleFileWithFollowSymlinkDisabled(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -3020,8 +2960,7 @@ func TestCopyLinkToASingleFileWithFollowSymlinkDisabled(t *testing.T) {
 func TestCopyWithFollowSymlink(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -3063,8 +3002,7 @@ func TestCopyWithFollowSymlink(t *testing.T) {
 func TestCopyErrorWhenGivenObjectIsNotFoundUsingWildcard(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -3095,8 +3033,7 @@ func TestCopyErrorWhenGivenObjectIsNotFoundUsingWildcard(t *testing.T) {
 func TestCopyWithNoFollowSymlink(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -3137,8 +3074,7 @@ func TestCopyDirToS3DryRun(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3184,8 +3120,7 @@ func TestCopyS3ToDirDryRun(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3293,8 +3228,7 @@ func TestCopyLocalObjectstoS3WithRawFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -3340,8 +3274,7 @@ func TestCopyDirToS3WithRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3463,8 +3396,7 @@ func TestCopyS3ObjectstoLocalWithRawFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -3500,8 +3432,7 @@ func TestCopyMultipleS3ObjectsToS3WithRawMode(t *testing.T) {
 	const bucket = "bucket"
 	const destBucket = "destbucket"
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	createBucket(t, s3client, destBucket)
@@ -3551,8 +3482,7 @@ func TestCopyMultipleS3ObjectsWithPrefixToS3WithRawMode(t *testing.T) {
 	const bucket = "bucket"
 	const destBucket = "destbucket"
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	createBucket(t, s3client, destBucket)
@@ -3589,8 +3519,7 @@ func TestCopyRawModeAllowDestinationWithoutPrefix(t *testing.T) {
 
 	const bucket = "bucket"
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3643,8 +3572,7 @@ func TestCopyS3ObjectsWithExcludeFilter(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3697,8 +3625,7 @@ func TestCopyS3ObjectsWithExcludeFilters(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3751,8 +3678,7 @@ func TestCopyS3ObjectsWithPrefixWithExcludeFilters(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3835,8 +3761,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 
 			bucket := "testbucket"
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -3902,8 +3827,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilters(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -3976,8 +3900,7 @@ func TestCopySingleS3ObjectsIntoAnotherBucketWithExcludeFilter(t *testing.T) {
 		dstbucket = "dstbucket"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -4053,8 +3976,7 @@ func TestCopySingleS3ObjectsIntoAnotherBucketWithExcludeFilters(t *testing.T) {
 		dstbucket = "dstbucket"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -4127,8 +4049,7 @@ func TestCopyExpectExitCode1OnUnreachableHost(t *testing.T) {
 
 	const bucket = "bucket"
 
-	_, s5cmd, cleanup := setup(t, withEndpointURL("nonExistingEndpointURL"))
-	defer cleanup()
+	_, s5cmd := setup(t, withEndpointURL("nonExistingEndpointURL"))
 
 	folderLayout := []fs.PathOp{
 		fs.WithFile("testfile.txt", "this is a test file 1"),
@@ -4152,8 +4073,7 @@ func TestCopySingleFileToS3WithNoSuchUploadRetryCount(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -4191,8 +4111,7 @@ func TestCopySingleFileToS3WithNoSuchUploadRetryCount(t *testing.T) {
 func TestDeleteFileWhenDownloadFailed(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	filename := "testfile1.txt"

--- a/e2e/du_test.go
+++ b/e2e/du_test.go
@@ -12,8 +12,7 @@ func TestDiskUsageSingleS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -36,8 +35,7 @@ func TestDiskUsageSingleS3ObjectJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -66,8 +64,7 @@ func TestDiskUsageMultipleS3Objects(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -90,8 +87,7 @@ func TestDiskUsageWildcard(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "this is a file content")
@@ -114,8 +110,7 @@ func TestDiskUsageS3ObjectsAndFolders(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "content")
@@ -144,8 +139,7 @@ func TestDiskUsageWildcardS3ObjectsWithDashH(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -168,8 +162,7 @@ func TestDiskUsageMissingObject(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -190,8 +183,7 @@ func TestDiskUsageWildcardWithExcludeFilter(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const excludePattern = "main*"
 
@@ -220,8 +212,7 @@ func TestDiskUsageWildcardWithExcludeFilters(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		excludePattern1 = "main*"

--- a/e2e/ls_test.go
+++ b/e2e/ls_test.go
@@ -14,8 +14,7 @@ import (
 func TestListBuckets(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	// alphabetically unordered list of buckets
 	bucketPrefix := s3BucketFromTestName(t)
@@ -42,8 +41,7 @@ func TestListBuckets(t *testing.T) {
 func TestListBucketsJSON(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	// alphabetically unordered list of buckets
 	bucketPrefix := s3BucketFromTestName(t)
@@ -72,8 +70,7 @@ func TestListSingleS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -97,8 +94,7 @@ func TestListSingleS3ObjectJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -122,8 +118,7 @@ func TestListSingleWildcardS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "this is a file content")
@@ -148,8 +143,7 @@ func TestListS3ObjectsWithDashS(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "this is a file content")
@@ -168,8 +162,7 @@ func TestListMultipleWildcardS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "a/testfile1.txt", "content")
@@ -205,8 +198,7 @@ func TestListMultipleWildcardS3ObjectWithPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "a/testfile1.txt", "content")
@@ -239,8 +231,7 @@ func TestListS3ObjectsAndFolders(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "content")
@@ -277,8 +268,7 @@ func TestListS3ObjectsAndFoldersWithPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "testfile1.txt", "content")
@@ -304,8 +294,7 @@ func TestListNonexistingS3ObjectInGivenPrefix(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -328,8 +317,7 @@ func TestListNonexistingS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -351,8 +339,7 @@ func TestListS3ObjectsWithDashE(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -376,8 +363,7 @@ func TestListS3ObjectsWithDashH(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -417,8 +403,7 @@ func TestListS3ObjectsWithExcludeFilter(t *testing.T) {
 		"file2.txt.extension", // this should not be excluded.
 	}
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -461,8 +446,7 @@ func TestListS3ObjectsWithExcludeFilters(t *testing.T) {
 		"file2.txt",
 	}
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -497,8 +481,7 @@ func TestListS3ObjectsWithEmptyExcludeFilter(t *testing.T) {
 		"file2.txt",
 	}
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -534,8 +517,7 @@ func TestListNestedPrefixedS3ObjectsWithExcludeFilter(t *testing.T) {
 		"some-dir/some-dir/some-dir/file.txt",
 	}
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -585,8 +567,7 @@ func TestListLocalFilesWithExcludeFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			_, s5cmd := setup(t)
 
 			const excludePattern = "main*"
 			folderLayout := []fs.PathOp{
@@ -625,8 +606,7 @@ func TestListLocalFilesWithExcludeFilter(t *testing.T) {
 func TestListLocalFilesWithExcludeFilters(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	const (
 		excludePattern1 = "main*"
@@ -666,8 +646,7 @@ func TestListLocalFilesWithExcludeFilters(t *testing.T) {
 func TestListLocalFilesWithPrefixAndExcludeFilter(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	const (
 		excludePattern1 = "main*"
@@ -706,8 +685,7 @@ func TestListLocalFilesWithPrefixAndExcludeFilter(t *testing.T) {
 func TestListNestedLocalFolders(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	const (
 		excludePattern1 = "some-dir/some-dir/file.txt"

--- a/e2e/mb_test.go
+++ b/e2e/mb_test.go
@@ -12,8 +12,7 @@ import (
 func TestMakeBucket_success(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucketName := "test-bucket"
 	src := fmt.Sprintf("s3://%s", bucketName)
@@ -36,8 +35,7 @@ func TestMakeBucket_success(t *testing.T) {
 func TestMakeBucket_success_json(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucketName := "test-bucket"
 	src := fmt.Sprintf("s3://%s", bucketName)
@@ -68,8 +66,7 @@ func TestMakeBucket_success_json(t *testing.T) {
 func TestMakeBucket_failure(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	bucketName := "invalid/bucket/name"
 	src := fmt.Sprintf("s3://%s", bucketName)
@@ -87,8 +84,7 @@ func TestMakeBucket_failure(t *testing.T) {
 func TestMakeBucket_failure_json(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	bucketName := "invalid/bucket/name"
 	src := fmt.Sprintf("s3://%s", bucketName)

--- a/e2e/mv_test.go
+++ b/e2e/mv_test.go
@@ -17,8 +17,7 @@ func TestMoveSingleS3ObjectToLocal(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -53,8 +52,7 @@ func TestMoveMultipleS3ObjectsToLocal(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -103,8 +101,7 @@ func TestMoveSingleFileToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -140,8 +137,7 @@ func TestMoveMultipleFilesToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -192,8 +188,7 @@ func TestMoveSingleS3ObjectToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -231,8 +226,7 @@ func TestMoveSingleS3ObjectIntoAnotherBucket(t *testing.T) {
 	srcbucket := s3BucketFromTestName(t)
 	dstbucket := "copy-" + s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -270,8 +264,7 @@ func TestMoveMultipleS3ObjectsToS3(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -319,8 +312,7 @@ func TestMoveMultipleS3ObjectsToS3DryRun(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -372,8 +364,7 @@ func TestMoveLocalObjectToS3WithRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 

--- a/e2e/proxy.go
+++ b/e2e/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
+	"testing"
 )
 
 // Hop-by-hop headers. These are removed when sent to the backend.
@@ -79,7 +80,10 @@ func (p *httpProxy) isSuccessful(totalReqs int64) bool {
 	return totalReqs == atomic.LoadInt64(&p.successReqs) && atomic.LoadInt64(&p.errorReqs) == 0
 }
 
-func setupProxy(p *httpProxy) (string, func()) {
+func setupProxy(t *testing.T, p *httpProxy) string {
 	proxysrv := httptest.NewServer(p)
-	return proxysrv.URL, proxysrv.Close
+	t.Cleanup(func() {
+		proxysrv.Close()
+	})
+	return proxysrv.URL
 }

--- a/e2e/proxy.go
+++ b/e2e/proxy.go
@@ -82,6 +82,7 @@ func (p *httpProxy) isSuccessful(totalReqs int64) bool {
 
 func setupProxy(t *testing.T, p *httpProxy) string {
 	proxysrv := httptest.NewServer(p)
+
 	t.Cleanup(func() {
 		proxysrv.Close()
 	})

--- a/e2e/rb_test.go
+++ b/e2e/rb_test.go
@@ -13,8 +13,7 @@ import (
 func TestRemoveBucketSuccess(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucketName := "bucket"
 	src := fmt.Sprintf("s3://%v", bucketName)
@@ -40,8 +39,7 @@ func TestRemoveBucketSuccess(t *testing.T) {
 func TestRemoveBucketSuccessJson(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucketName := "bucket"
 	src := fmt.Sprintf("s3://%v", bucketName)
@@ -74,8 +72,7 @@ func TestRemoveBucketSuccessJson(t *testing.T) {
 func TestRemoveBucketFailure(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	bucketName := "invalid/bucket/name"
 	src := fmt.Sprintf("s3://%s", bucketName)
@@ -92,8 +89,7 @@ func TestRemoveBucketFailure(t *testing.T) {
 func TestRemoveBucketFailureJson(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	bucketName := "invalid/bucket/name"
 	src := fmt.Sprintf("s3://%s", bucketName)
@@ -116,8 +112,7 @@ func TestRemoveBucketWithObject(t *testing.T) {
 		fileName    = "file1.txt"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, fileName, fileContent)

--- a/e2e/rm_test.go
+++ b/e2e/rm_test.go
@@ -17,8 +17,7 @@ func TestRemoveSingleS3Object(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -51,8 +50,7 @@ func TestRemoveSingleS3ObjectJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -91,8 +89,7 @@ func TestRemoveMultipleS3Objects(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -134,8 +131,7 @@ func TestRemoveMultipleS3ObjectsJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -207,8 +203,7 @@ func TestRemoveTenThousandS3Objects(t *testing.T) {
 
 	// ten thousand s3 objects are created for this test. by default, s3 backend is
 	// bolt but we need speed for this test, hence use in-memory storage.
-	s3client, s5cmd, cleanup := setup(t, withS3Backend("mem"))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withS3Backend("mem"))
 
 	createBucket(t, s3client, bucket)
 
@@ -253,8 +248,7 @@ func TestRemoveS3PrefixWithoutSlash(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -277,8 +271,7 @@ func TestRemoveS3PrefixWithoutSlash(t *testing.T) {
 func TestRemoveSingleLocalFile(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -308,8 +301,7 @@ func TestRemoveSingleLocalFile(t *testing.T) {
 func TestRemoveMultipleLocalFilesShouldNotFail(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	filesToContent := map[string]string{
 		"testfile1.txt":          "this is a test file 1",
@@ -352,8 +344,7 @@ func TestRemoveMultipleLocalFilesShouldNotFail(t *testing.T) {
 func TestRemoveLocalDirectory(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	folderLayout := []fs.PathOp{
 		fs.WithDir(
@@ -393,8 +384,7 @@ func TestRemoveLocalDirectoryWithGlob(t *testing.T) {
 		t.Skip("Files in Windows cannot contain glob(*) characters")
 	}
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	folderLayout := []fs.PathOp{
 		fs.WithDir(
@@ -445,8 +435,7 @@ func TestRemoveLocalDirectoryWithGlob(t *testing.T) {
 func TestVariadicMultipleLocalFilesWithDirectory(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	folderLayout := []fs.PathOp{
 		fs.WithDir(
@@ -482,8 +471,7 @@ func TestVariadicMultipleLocalFilesWithDirectory(t *testing.T) {
 func TestVariadicRemoveS3Objects(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -532,8 +520,7 @@ func TestVariadicRemoveS3Objects(t *testing.T) {
 func TestVariadicRemoveS3ObjectsWithWildcard(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -583,8 +570,7 @@ func TestVariadicRemoveS3ObjectsWithWildcard(t *testing.T) {
 func TestRemoveMultipleMixedObjects(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const bucket = "bucket"
 	createBucket(t, s3client, bucket)
@@ -626,8 +612,7 @@ func TestRemoveMultipleS3ObjectsDryRun(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -667,8 +652,7 @@ func TestRemoveS3ObjectRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -721,8 +705,7 @@ func TestRemoveS3ObjectsPrefixRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -767,8 +750,7 @@ func TestRemoveS3PrefixRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -807,8 +789,7 @@ func TestRemoveMultipleS3ObjectsWithExcludeFilter(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	const excludePattern = "*.txt"
@@ -871,8 +852,7 @@ func TestRemoveMultipleS3ObjectsWithExcludeFilters(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -936,8 +916,7 @@ func TestRemoveMultipleS3ObjectsWithExcludeFilters(t *testing.T) {
 func TestRemoveS3ObjectsWithEmptyExcludeFilter(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1009,8 +988,7 @@ func TestRemoveLocalDirectoryWithExcludeFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			_, s5cmd := setup(t)
 
 			folderLayout := []fs.PathOp{
 				fs.WithDir(
@@ -1059,8 +1037,7 @@ func TestRemoveLocalDirectoryWithExcludeFilter(t *testing.T) {
 func TestRemoveLocalFilesWithExcludeFilters(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	folderLayout := []fs.PathOp{
 		fs.WithDir(
@@ -1116,8 +1093,7 @@ func TestRemoveLocalFilesWithExcludeFilters(t *testing.T) {
 func TestRemoveLocalFilesWithPrefixandExcludeFilters(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	folderLayout := []fs.PathOp{
 		fs.WithDir(
@@ -1175,8 +1151,7 @@ func TestRemoveLocalFilesWithPrefixandExcludeFilters(t *testing.T) {
 func TestRemovetNonexistingLocalFile(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("rm", "nonexistentfile")
 	result := icmd.RunCmd(cmd)

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -16,8 +16,7 @@ func TestRunFromStdin(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file1.txt", "content")
@@ -49,8 +48,7 @@ func TestRunFromStdinIssue309(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "test #3 /bar.jpg", "content")
@@ -78,8 +76,7 @@ func TestRunFromStdinWithErrors(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -107,8 +104,7 @@ func TestRunFromStdinJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file1.txt", "content")
@@ -138,8 +134,7 @@ func TestRunFromFile(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file1.txt", "content")
@@ -171,8 +166,7 @@ func TestRunFromFileJSON(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file1.txt", "content")
@@ -202,8 +196,7 @@ func TestRunFromFileJSON(t *testing.T) {
 func TestRunFromFileThatDoesntExist(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("run", "non-existent-file")
 	result := icmd.RunCmd(cmd)
@@ -222,8 +215,7 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file.txt", "content")
@@ -258,8 +250,7 @@ func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	sourceFileName := `special-chars_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =/_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =image.jpg`
 	targetFilePath := `./image.jpg`
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, sourceFileName, "content")
@@ -287,8 +278,7 @@ func TestRunDryRun(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -336,8 +326,7 @@ func TestRunFixDataRace_Issue301(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 	putFile(t, s3client, bucket, "file1.txt", "content")

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -12,7 +12,7 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, timeSource gofakes3.TimeSource, enableProxy bool) (string, func()) {
+func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, timeSource gofakes3.TimeSource, enableProxy bool) string {
 	var s3backend gofakes3.Backend
 	switch backend {
 	case "mem":
@@ -53,11 +53,12 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 	faker := gofakes3.New(s3backend, opts...)
 	s3srv := httptest.NewServer(faker.Server())
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		s3srv.Close()
 		// no need to remove boltdb file since 'testdir' will be cleaned up
 		// after each test.
-	}
+
+	})
 
 	if enableProxy {
 		parsedUrl, err := url.Parse(s3srv.URL)
@@ -65,7 +66,7 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 			t.Fatal(err)
 		}
 		proxyEnabledURL := "http://localhost.:" + parsedUrl.Port()
-		return proxyEnabledURL, cleanup
+		return proxyEnabledURL
 	}
-	return s3srv.URL, cleanup
+	return s3srv.URL
 }

--- a/e2e/s3_fake.go
+++ b/e2e/s3_fake.go
@@ -57,7 +57,6 @@ func s3ServerEndpoint(t *testing.T, testdir *fs.Dir, loglvl, backend string, tim
 		s3srv.Close()
 		// no need to remove boltdb file since 'testdir' will be cleaned up
 		// after each test.
-
 	})
 
 	if enableProxy {

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -16,8 +16,7 @@ import (
 func TestSyncFailForNonsharedFlagsFromCopyCommand(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "source.go"
@@ -44,8 +43,7 @@ func TestSyncFailForNonsharedFlagsFromCopyCommand(t *testing.T) {
 func TestSyncLocalToLocal(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	sourceWorkDir := fs.NewDir(t, "source")
 	destWorkDir := fs.NewDir(t, "dest")
@@ -67,8 +65,7 @@ func TestSyncLocalToLocal(t *testing.T) {
 func TestSyncSingleS3ObjectToLocalTwice(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "source.go"
@@ -100,8 +97,7 @@ func TestSyncLocalFileToS3Twice(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	const (
 		filename = "testfile1.txt"
@@ -141,8 +137,7 @@ func TestCopyLocalFilestoS3WithRawFlag(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -193,8 +188,7 @@ func TestCopyLocalFilestoS3WithRawFlag(t *testing.T) {
 // sync folder/ s3://bucket
 func TestSyncLocalFolderToS3EmptyBucket(t *testing.T) {
 	t.Parallel()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -252,8 +246,7 @@ func TestSyncMultipleFilesWithWildcardedDirectoryToS3Bucket(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, bucket)
 
@@ -302,8 +295,7 @@ func TestSyncMultipleFilesWithWildcardedDirectoryToS3Bucket(t *testing.T) {
 // sync  s3://bucket/* folder/
 func TestSyncS3BucketToEmptyFolder(t *testing.T) {
 	t.Parallel()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -365,8 +357,7 @@ func TestSyncS3BucketToEmptyFolder(t *testing.T) {
 // sync  s3://bucket/* s3://destbucket/prefix/
 func TestSyncS3BucketToEmptyS3Bucket(t *testing.T) {
 	t.Parallel()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	const (
@@ -421,8 +412,7 @@ func TestSyncLocalFolderToS3BucketSameObjectsSourceOlder(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -498,8 +488,7 @@ func TestSyncLocalFolderToS3BucketSourceNewer(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -577,8 +566,7 @@ func TestSyncS3BucketToLocalFolderSameObjectsSourceOlder(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -658,8 +646,7 @@ func TestSyncS3BucketToLocalFolderSameObjectsSourceNewer(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -736,8 +723,7 @@ func TestSyncS3BucketToS3BucketSameSizesSourceNewer(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	destbucket := "destbucket"
@@ -805,8 +791,7 @@ func TestSyncS3BucketToS3BucketSameSizesSourceOlder(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	destbucket := "destbucket"
@@ -871,8 +856,7 @@ func TestSyncS3BucketToS3BucketSameSizesSourceOlder(t *testing.T) {
 // sync --size-only s3://bucket/* folder/
 func TestSyncS3BucketToLocalFolderSameObjectsSizeOnly(t *testing.T) {
 	t.Parallel()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -948,8 +932,7 @@ func TestSyncS3BucketToLocalFolderSameObjectsSizeOnly(t *testing.T) {
 func TestSyncLocalFolderToS3BucketSameObjectsSizeOnly(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1024,8 +1007,7 @@ func TestSyncS3BucketToS3BucketSizeOnly(t *testing.T) {
 
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	destbucket := "destbucket"
@@ -1096,8 +1078,7 @@ func TestSyncS3BucketToS3BucketSizeOnly(t *testing.T) {
 // sync --delete s3://bucket/* .
 func TestSyncS3BucketToLocalWithDelete(t *testing.T) {
 	t.Parallel()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1157,8 +1138,7 @@ func TestSyncLocalToS3BucketWithDelete(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1226,8 +1206,7 @@ func TestSyncLocalToS3BucketWithDelete(t *testing.T) {
 func TestSyncS3BucketToS3BucketWithDelete(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	destbucket := "destbucket"
@@ -1308,8 +1287,7 @@ func TestSyncS3toLocalWithWildcard(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 	timeSource := newFixedTimeSource(now)
-	s3client, s5cmd, cleanup := setup(t, withTimeSource(timeSource))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withTimeSource(timeSource))
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1373,8 +1351,7 @@ func TestSyncS3toLocalWithWildcard(t *testing.T) {
 func TestSyncS3BucketToLocalWithDeleteFlag(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1424,8 +1401,7 @@ func TestSyncS3BucketToLocalWithDeleteFlag(t *testing.T) {
 func TestSyncLocalFilesWithSymlinksToS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1464,8 +1440,7 @@ func TestSyncLocalFilesWithSymlinksToS3Bucket(t *testing.T) {
 func TestSyncLocalFilesWithNoFollowSymlinksToS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	bucket := s3BucketFromTestName(t)
 	createBucket(t, s3client, bucket)
@@ -1507,8 +1482,7 @@ func TestSyncS3ObjectsIntoAnotherBucketWithExcludeFilters(t *testing.T) {
 		dstbucket = "dstbucket"
 	)
 
-	s3client, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	s3client, s5cmd := setup(t)
 
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
@@ -1614,8 +1588,7 @@ func TestSyncLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 
 			bucket := "testbucket"
 
-			s3client, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			s3client, s5cmd := setup(t)
 
 			createBucket(t, s3client, bucket)
 
@@ -1681,8 +1654,7 @@ func TestIssue435(t *testing.T) {
 
 	bucket := s3BucketFromTestName(t)
 
-	s3client, s5cmd, cleanup := setup(t, withS3Backend("mem"))
-	defer cleanup()
+	s3client, s5cmd := setup(t, withS3Backend("mem"))
 
 	createBucket(t, s3client, bucket)
 

--- a/e2e/version_test.go
+++ b/e2e/version_test.go
@@ -9,8 +9,7 @@ import (
 func TestVersion(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd, cleanup := setup(t)
-	defer cleanup()
+	_, s5cmd := setup(t)
 
 	cmd := s5cmd("version")
 	result := icmd.RunCmd(cmd)


### PR DESCRIPTION
Use [t.Cleanup](https://pkg.go.dev/testing#T.Cleanup) which was added in Go 1.14 instead of passing cleanup functions and handling them manually.