### PR TITLE
e2e/app_test: fix failed test due to new cleanup

### DIFF
--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -255,8 +255,7 @@ func TestAppEndpointShouldHaveScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, s5cmd, cleanup := setup(t)
-			defer cleanup()
+			_, s5cmd := setup(t)
 
 			cmd := s5cmd("--endpoint-url", tc.endpointUrl)
 			result := icmd.RunCmd(cmd)


### PR DESCRIPTION
`TestAppEndpointShouldHaveScheme` was added after the refactor of t.Cleanup. Change that test setup according to the refactor.