### PR TITLE
storage/s3: add `SlowDown` as retryable

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -978,7 +978,7 @@ func newCustomRetryer(maxRetries int) *customRetryer {
 // ShouldRetry overrides SDK's built in DefaultRetryer, adding custom retry
 // logics that are not included in the SDK.
 func (c *customRetryer) ShouldRetry(req *request.Request) bool {
-	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") || strings.Contains(req.Error.Error(), "connection reset") || strings.Contains(req.Error.Error(), "connection timed out")
+	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") || errHasCode(req.Error, "SlowDown") || strings.Contains(req.Error.Error(), "connection reset") || strings.Contains(req.Error.Error(), "connection timed out")
 	if !shouldRetry {
 		shouldRetry = c.DefaultRetryer.ShouldRetry(req)
 	}

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -447,6 +447,11 @@ func TestS3Retry(t *testing.T) {
 			err:           awserr.New("RequestTimeTooSkewed", "The difference between the request time and the server's time is too large.", nil),
 			expectedRetry: 5,
 		},
+		{
+			name:          "SlowDown",
+			err:           awserr.New("SlowDown", "Please reduce your request rate.", nil),
+			expectedRetry: 5,
+		},
 
 		// Throttling errors
 		{


### PR DESCRIPTION
in [v0.7.0](https://github.com/peak/s5cmd/blob/v0.7.0/core/error.go#L49), SlowDown was a retryable error. 

Add that again as retryable because with #506, one might get slowdown errors while testing with other endpoint urls.