### PR TITLE
.github/workflows: Add external endpoint test before release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,7 +4,25 @@ on:
     tags:
       - 'v*'
 jobs:
+  gcs_test:
+    name: gcs-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+      - run: make test_without_race
+        env:
+          S5CMD_ACCESS_KEY_ID: ${{ secrets.S5CMD_GCS_ACCESS_KEY_ID }}
+          S5CMD_SECRET_ACCESS_KEY: ${{ secrets.S5CMD_GCS_SECRET_ACCESS_KEY }}
+          S5CMD_ENDPOINT_URL: https://storage.googleapis.com
+          S5CMD_IS_VIRTUAL_HOST: 1
+          S5CMD_REGION: ${{ secrets.S5CMD_GCS_REGION }}
+          S5CMD_I_KNOW_WHAT_IM_DOING: 1
+
   goreleaser:
+    needs: [ gcs_test ]
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
This PR adds one blocker test for external endpoint `google-cloud-storage` before release. If those tests don't pass, release will fail.

As a future improvement, we can also write another blocker test for `amazon-s3` server. However, as I don't have any chance to test implementation for amazon s3, I did not add it here as a github action.

After this PR, folllowing secrets needs to be added to be able to run these `gcs` tests successfully:

```
- secrets.S5CMD_GCS_ACCESS_KEY_ID
- secrets.S5CMD_GCS_SECRET_ACCESS_KEY
- secrets.S5CMD_GCS_REGION
```
