### PR TITLE
log, parallel: fix help flag panicking

### DIFF
--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/peak/s5cmd/command"
+
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -199,10 +201,9 @@ func TestAppHelp(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	// with specific commands
-	cmdList := []string{"ls", "cp", "rm", "mv", "mb", "rb", "select", "du", "cat", "run", "sync"}
-	for _, command := range cmdList {
-		cmd := s5cmd(command, "--help")
+	// with commands
+	for _, command := range command.Commands() {
+		cmd := s5cmd(command.Name, "--help")
 		result = icmd.RunCmd(cmd)
 
 		result.Assert(t, icmd.Success)

--- a/e2e/app_test.go
+++ b/e2e/app_test.go
@@ -188,6 +188,27 @@ func TestAppUnknownCommand(t *testing.T) {
 	})
 }
 
+func TestAppHelp(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	// without any specific command
+	cmd := s5cmd("--help")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	// with specific commands
+	cmdList := []string{"ls", "cp", "rm", "mv", "mb", "rb", "select", "du", "cat", "run", "sync"}
+	for _, command := range cmdList {
+		cmd := s5cmd(command, "--help")
+		result = icmd.RunCmd(cmd)
+
+		result.Assert(t, icmd.Success)
+	}
+}
+
 func TestUsageError(t *testing.T) {
 	t.Parallel()
 

--- a/log/log.go
+++ b/log/log.go
@@ -50,8 +50,10 @@ func Error(msg Message) {
 
 // Close closes logger and its channel.
 func Close() {
-	close(outputCh)
-	<-global.donech
+	if global != nil {
+		close(outputCh)
+		<-global.donech
+	}
 }
 
 // Logger is a structure for logging messages.

--- a/parallel/global.go
+++ b/parallel/global.go
@@ -13,7 +13,11 @@ func Init(workercount int) {
 
 // Close waits all jobs to finish and
 // closes the semaphore of global ParallelManager.
-func Close() { global.Close() }
+func Close() {
+	if global != nil {
+		global.Close()
+	}
+}
 
 // Run runs global ParallelManager.
 func Run(task Task, waiter *Waiter) { global.Run(task, waiter) }


### PR DESCRIPTION
after #495, `s5cmd --help` started to panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x158798e]

goroutine 1 [running]:
github.com/peak/s5cmd/parallel.(*Manager).Close(...)
        /Users/boraberke/Documents/s5cmd/parallel/parallel.go:65
github.com/peak/s5cmd/parallel.Close(...)
        /Users/boraberke/Documents/s5cmd/parallel/global.go:16
github.com/peak/s5cmd/command.glob..func5(0x16af2c0?)
        /Users/boraberke/Documents/s5cmd/command/app.go:177 +0x10e
github.com/urfave/cli/v2.(*App).RunContext.func1()
        /Users/boraberke/Documents/s5cmd/vendor/github.com/urfave/cli/v2/app.go:309 +0x35
github.com/urfave/cli/v2.(*App).RunContext(0x1bf3c20, {0x1857a30?, 0xc000030e80}, {0xc000020040, 0x2, 0x2})
        /Users/boraberke/Documents/s5cmd/vendor/github.com/urfave/cli/v2/app.go:321 +0xa5b
github.com/peak/s5cmd/command.Main({0x1857a30, 0xc000030e80}, {0xc000020040, 0x2, 0x2})
        /Users/boraberke/Documents/s5cmd/command/app.go:235 +0xa6
main.main()
        /Users/boraberke/Documents/s5cmd/main.go:23 +0x9b
```

This is caused by [this commit](https://github.com/urfave/cli/commit/a1c26d5491ccae4a23f39c263445907256154793) from urfave/cli. `app.After` is deferred before `showAppHelp` is called. Fix this bug by making nil checks in log.go and parallel.go