### PR TITLE
storage/url: add nil check for URL.filterRegex in URL.Match

### DIFF
--- a/storage/url/url.go
+++ b/storage/url/url.go
@@ -326,6 +326,10 @@ func (u *URL) SetRelative(base *URL) {
 
 // Match reports whether if given key matches with the object.
 func (u *URL) Match(key string) bool {
+	if u.filterRegex == nil {
+		return false
+	}
+
 	if !u.filterRegex.MatchString(key) {
 		return false
 	}


### PR DESCRIPTION
URL.Match method assumes that URL.filterRegex is not nil and used it without check. But if the URL was created with `raw` option or was created with type literal then it might be nil. So if Match was called for such URLs then it panics.

ps. It occured in an old variants of autocompletion PR. But that part of the code was changed now, so we won't include this change there. 
