### PR TITLE
Introduce a flag to preserve timestamps of files

### DIFF
--- a/command/sync.go
+++ b/command/sync.go
@@ -114,8 +114,9 @@ type Sync struct {
 	fullCommand string
 
 	// flags
-	delete   bool
-	sizeOnly bool
+	delete            bool
+	sizeOnly          bool
+	preserveTimestamp bool
 
 	// s3 options
 	storageOpts storage.Options
@@ -137,8 +138,9 @@ func NewSync(c *cli.Context) Sync {
 		fullCommand: commandFromContext(c),
 
 		// flags
-		delete:   c.Bool("delete"),
-		sizeOnly: c.Bool("size-only"),
+		delete:            c.Bool("delete"),
+		sizeOnly:          c.Bool("size-only"),
+		preserveTimestamp: c.Bool("preserve-timestamp"),
 
 		// flags
 		followSymlinks: !c.Bool("no-follow-symlinks"),
@@ -357,6 +359,9 @@ func (s Sync) planRun(
 	// try to expand given source.
 	defaultFlags := map[string]interface{}{
 		"raw": true,
+	}
+	if s.preserveTimestamp {
+		defaultFlags["preserve-timestamp"] = s.preserveTimestamp
 	}
 
 	// only in source

--- a/storage/fs_darwin.go
+++ b/storage/fs_darwin.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package storage
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func GetFileTime(filename string) (time.Time, time.Time, time.Time, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return time.Time{}, time.Time{}, time.Time{}, err
+	}
+
+	stat := fi.Sys().(*syscall.Stat_t)
+	cTime := time.Unix(int64(stat.Ctimespec.Sec), int64(stat.Ctimespec.Nsec))
+	aTime := time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec))
+
+	mTime := fi.ModTime()
+
+	return aTime, mTime, cTime, nil
+}
+
+func SetFileTime(filename string, accessTime, modificationTime, creationTime time.Time) error {
+	var err error
+	if accessTime.IsZero() && modificationTime.IsZero() {
+		// Nothing recorded in s3. Return fast.
+		return nil
+	} else if accessTime.IsZero() {
+		accessTime, _, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	} else if modificationTime.IsZero() {
+		_, modificationTime, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	}
+	err = os.Chtimes(filename, accessTime, modificationTime)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/fs_linux.go
+++ b/storage/fs_linux.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package storage
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func GetFileTime(filename string) (time.Time, time.Time, time.Time, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return time.Time{}, time.Time{}, time.Time{}, err
+	}
+
+	stat := fi.Sys().(*syscall.Stat_t)
+	cTime := time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+	aTime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+
+	mTime := fi.ModTime()
+
+	return aTime, mTime, cTime, nil
+}
+
+func SetFileTime(filename string, accessTime, modificationTime, creationTime time.Time) error {
+	if accessTime.IsZero() && modificationTime.IsZero() {
+		// Nothing recorded in s3. Return fast.
+		return nil
+	}
+	var err error
+	if accessTime.IsZero() {
+		accessTime, _, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	}
+	if modificationTime.IsZero() {
+		_, modificationTime, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	}
+	err = os.Chtimes(filename, accessTime, modificationTime)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/fs_windows.go
+++ b/storage/fs_windows.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package storage
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func GetFileTime(filename string) (time.Time, time.Time, time.Time, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return time.Time{}, time.Time{}, time.Time{}, err
+	}
+
+	d := fi.Sys().(*syscall.Win32FileAttributeData)
+	cTime := time.Unix(0, d.CreationTime.Nanoseconds())
+	aTime := time.Unix(0, d.LastAccessTime.Nanoseconds())
+
+	mTime := fi.ModTime()
+
+	return aTime, mTime, cTime, nil
+}
+
+func SetFileTime(filename string, accessTime, modificationTime, creationTime time.Time) error {
+	var err error
+	if accessTime.IsZero() && modificationTime.IsZero() && creationTime.IsZero() {
+		// Nothing recorded in s3. Return fast.
+		return nil
+	} else if accessTime.IsZero() {
+		accessTime, _, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	} else if modificationTime.IsZero() {
+		_, modificationTime, _, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	} else if creationTime.IsZero() {
+		_, _, creationTime, err = GetFileTime(filename)
+		if err != nil {
+			return err
+		}
+	}
+
+	aft := syscall.NsecToFiletime(accessTime.UnixNano())
+	mft := syscall.NsecToFiletime(modificationTime.UnixNano())
+	cft := syscall.NsecToFiletime(creationTime.UnixNano())
+
+	fd, err := syscall.Open(filename, os.O_RDWR, 0775)
+	if err != nil {
+		return err
+	}
+	err = syscall.SetFileTime(fd, &cft, &aft, &mft)
+
+	defer syscall.Close(fd)
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/peak/s5cmd/log"
@@ -105,7 +106,9 @@ func (o *Options) SetRegion(region string) {
 type Object struct {
 	URL          *url.URL     `json:"key,omitempty"`
 	Etag         string       `json:"etag,omitempty"`
+	AccessTime   *time.Time   `json:"accessed,omitempty"`
 	ModTime      *time.Time   `json:"last_modified,omitempty"`
+	CreateTime   *time.Time   `json:"created,omitempty"`
 	Type         ObjectType   `json:"type,omitempty"`
 	Size         int64        `json:"size,omitempty"`
 	StorageClass StorageClass `json:"storage_class,omitempty"`
@@ -233,6 +236,25 @@ func (m Metadata) Expires() string {
 
 func (m Metadata) SetExpires(expires string) Metadata {
 	m["Expires"] = expires
+	return m
+}
+
+func (m Metadata) cTime() string {
+	return m["file-ctime"]
+}
+
+func (m Metadata) mTime() string {
+	return m["file-mtime"]
+}
+
+func (m Metadata) aTime() string {
+	return m["file-atime"]
+}
+
+func (m Metadata) SetPreserveTimestamp(aTime, mTime, cTime time.Time) Metadata {
+	m["file-ctime"] = strconv.Itoa(int(cTime.UnixNano()))
+	m["file-mtime"] = strconv.Itoa(int(mTime.UnixNano()))
+	m["file-atime"] = strconv.Itoa(int(aTime.UnixNano()))
 	return m
 }
 


### PR DESCRIPTION
This PR is in response to issue #532 

We are implementing a flag that when activated will record and store ctime, mtime, and atime in S3 as metadata on the object.
When pulling files down, if that data exists, we will set it on the files as well.

Linux & Darwin don't appear to allow setting of ctime, however atime and mtime are preserved.
Windows does allow us to set ctime, mtime, and atime, however they are actually referred to as CreationTime, LastAccessTime, and LastWriteTime.

Please let me know if you have feedback on this PR.
Thanks!