### PR TITLE
readme: fix `ci` badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report](https://goreportcard.com/badge/github.com/peak/s5cmd)](https://goreportcard.com/report/github.com/peak/s5cmd) ![Github Actions Status](https://github.com/peak/s5cmd/workflows/CI/badge.svg)
+[![Go Report](https://goreportcard.com/badge/github.com/peak/s5cmd)](https://goreportcard.com/report/github.com/peak/s5cmd) ![Github Actions Status](https://github.com/peak/s5cmd/actions/workflows/ci.yml/badge.svg)
 
 ![](./doc/s5cmd_header.jpg)
 


### PR DESCRIPTION
Appearently Github broke badge URLs. Update to new one.

<img width="327" alt="Screen Shot 2023-01-31 at 17 13 31" src="https://user-images.githubusercontent.com/8654/215784032-0996bb68-6098-49ff-81d0-46354a0338ec.png">
