### PR TITLE
command/rm: introduce --max-batch option

### DIFF
--- a/storage/fs.go
+++ b/storage/fs.go
@@ -179,7 +179,7 @@ func (f *Filesystem) Delete(ctx context.Context, url *url.URL) error {
 }
 
 // MultiDelete deletes all files returned from given channel.
-func (f *Filesystem) MultiDelete(ctx context.Context, urlch <-chan *url.URL) <-chan *Object {
+func (f *Filesystem) MultiDelete(ctx context.Context, urlch <-chan *url.URL, max int) <-chan *Object {
 	resultch := make(chan *Object)
 	go func() {
 		defer close(resultch)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -45,7 +45,7 @@ type Storage interface {
 	Delete(ctx context.Context, src *url.URL) error
 
 	// MultiDelete deletes all items returned from given urls in batches.
-	MultiDelete(ctx context.Context, urls <-chan *url.URL) <-chan *Object
+	MultiDelete(ctx context.Context, urls <-chan *url.URL, max int) <-chan *Object
 
 	// Copy src to dst, optionally setting the given metadata. Src and dst
 	// arguments are of the same type. If src is a remote type, server side


### PR DESCRIPTION
The default value of 1000 objects in one DeleteObjects request can be too high for some S3 storage providers, the deletions of such amount of objects can take some time which can be interpreted as a failure by timeout. Retries would generate even more DeleteObjects requests that would only worsen the situation.

Solution: allow users to specify the number of objects in a single DeleteObjects requests with --max-batch option.