### PR TITLE
command: update misleading help descriptions

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -45,7 +45,7 @@ Examples:
 		 > s5cmd {{.HelpName}} s3://bucket/prefix/object.gz myobject.gz
 
 	03. Download all S3 objects to a directory
-		 > s5cmd {{.HelpName}} s3://bucket/* target-directory/
+		 > s5cmd {{.HelpName}} "s3://bucket/*" target-directory/
 
 	04. Download an S3 object from a public bucket
 		 > s5cmd --no-sign-request {{.HelpName}} s3://bucket/prefix/object.gz .
@@ -54,7 +54,7 @@ Examples:
 		 > s5cmd {{.HelpName}} myfile.gz s3://bucket/
 
 	06. Upload matching files to S3 bucket
-		 > s5cmd {{.HelpName}} dir/*.gz s3://bucket/
+		 > s5cmd {{.HelpName}} "dir/*.gz" s3://bucket/
 
 	07. Upload all files in a directory to S3 bucket recursively
 		 > s5cmd {{.HelpName}} dir/ s3://bucket/
@@ -63,13 +63,13 @@ Examples:
 		 > s5cmd {{.HelpName}} s3://bucket/object s3://target-bucket/prefix/object
 
 	09. Copy matching S3 objects to another bucket
-		 > s5cmd {{.HelpName}} s3://bucket/*.gz s3://target-bucket/prefix/
+		 > s5cmd {{.HelpName}} "s3://bucket/*.gz" s3://target-bucket/prefix/
 
 	10. Copy files in a directory to S3 prefix if not found on target
 		 > s5cmd {{.HelpName}} -n -s -u dir/ s3://bucket/target-prefix/
 
 	11. Copy files in an S3 prefix to another S3 prefix if not found on target
-		 > s5cmd {{.HelpName}} -n -s -u s3://bucket/source-prefix/* s3://bucket/target-prefix/
+		 > s5cmd {{.HelpName}} -n -s -u "s3://bucket/source-prefix/*" s3://bucket/target-prefix/
 
 	12. Perform KMS Server Side Encryption of the object(s) at the destination
 		 > s5cmd {{.HelpName}} --sse aws:kms s3://bucket/object s3://target-bucket/prefix/object
@@ -78,7 +78,7 @@ Examples:
 		 > s5cmd {{.HelpName}} --sse aws:kms --sse-kms-key-id <your-kms-key-id> s3://bucket/object s3://target-bucket/prefix/object
 
 	14. Force transfer of GLACIER objects with a prefix whether they are restored or not
-		 > s5cmd {{.HelpName}} --force-glacier-transfer s3://bucket/prefix/* target-directory/
+		 > s5cmd {{.HelpName}} --force-glacier-transfer "s3://bucket/prefix/*" target-directory/
 
 	15. Upload a file to S3 bucket with public read s3 acl
 		 > s5cmd {{.HelpName}} --acl "public-read" myfile.gz s3://bucket/
@@ -93,7 +93,7 @@ Examples:
 		 > s5cmd {{.HelpName}} --exclude "*.txt" --exclude "*.gz" dir/ s3://bucket
 
 	19. Copy all files from S3 bucket to another S3 bucket but exclude the ones starts with log
-		 > s5cmd {{.HelpName}} --exclude "log*" s3://bucket/* s3://destbucket
+		 > s5cmd {{.HelpName}} --exclude "log*" "s3://bucket/*" s3://destbucket
 
 	20. Download an S3 object from a requester pays bucket
 		 > s5cmd --request-payer=requester {{.HelpName}} s3://bucket/prefix/object.gz .

--- a/command/mv.go
+++ b/command/mv.go
@@ -23,7 +23,7 @@ Examples:
 		 > s5cmd {{.HelpName}} s3://bucket/prefix/object.gz myobject.gz
 
 	3. Move all S3 objects to a directory
-		 > s5cmd {{.HelpName}} s3://bucket/* target-directory/
+		 > s5cmd {{.HelpName}} "s3://bucket/*" target-directory/
 
 	4. Move a file to S3 bucket
 		 > s5cmd {{.HelpName}} myfile.gz s3://bucket/
@@ -35,7 +35,7 @@ Examples:
 		 > s5cmd {{.HelpName}} --exclude "*.txt" --exclude "*.gz" dir/ s3://bucket
 
 	7. Move all files from S3 bucket to another S3 bucket but exclude the ones starts with log
-		 > s5cmd {{.HelpName}} --exclude "log*" s3://bucket/* s3://destbucket
+		 > s5cmd {{.HelpName}} --exclude "log*" "s3://bucket/*" s3://destbucket
 `
 
 func NewMoveCommand() *cli.Command {

--- a/command/select.go
+++ b/command/select.go
@@ -28,7 +28,7 @@ Options:
 	{{end}}
 Examples:
 	01. Search for all JSON objects with the foo property set to 'bar' and spit them into stdout
-		 > s5cmd {{.HelpName}} --compression gzip --query "SELECT * FROM S3Object s WHERE s.foo='bar'" s3://bucket/*
+		 > s5cmd {{.HelpName}} --compression gzip --query "SELECT * FROM S3Object s WHERE s.foo='bar'" "s3://bucket/*"
 `
 
 func NewSelectCommand() *cli.Command {

--- a/command/sync.go
+++ b/command/sync.go
@@ -39,22 +39,22 @@ Examples:
 		 > s5cmd {{.HelpName}} folder/ s3://bucket/
 
 	02. Sync S3 bucket to local folder
-		 > s5cmd {{.HelpName}} s3://bucket/* folder/
+		 > s5cmd {{.HelpName}} "s3://bucket/*" folder/
 
 	03. Sync S3 bucket objects under prefix to S3 bucket.
-		 > s5cmd {{.HelpName}} s3://sourcebucket/prefix/* s3://destbucket/
+		 > s5cmd {{.HelpName}} "s3://sourcebucket/prefix/*" s3://destbucket/
 
 	04. Sync local folder to S3 but delete the files that S3 bucket has but local does not have.
 		 > s5cmd {{.HelpName}} --delete folder/ s3://bucket/
 
 	05. Sync S3 bucket to local folder but use size as only comparison criteria.
-		 > s5cmd {{.HelpName}} --size-only s3://bucket/* folder/
+		 > s5cmd {{.HelpName}} --size-only "s3://bucket/*" folder/
 
 	06. Sync a file to S3 bucket
 		 > s5cmd {{.HelpName}} myfile.gz s3://bucket/
 
 	07. Sync matching S3 objects to another bucket
-		 > s5cmd {{.HelpName}} s3://bucket/*.gz s3://target-bucket/prefix/
+		 > s5cmd {{.HelpName}} "s3://bucket/*.gz" s3://target-bucket/prefix/
 
 	08. Perform KMS Server Side Encryption of the object(s) at the destination
 		 > s5cmd {{.HelpName}} --sse aws:kms s3://bucket/object s3://target-bucket/prefix/object


### PR DESCRIPTION
This PR updates the help messages for the commands that takes arguments containing wildcards. Since the expansion of wildcards are evaluated by the shell and not by the `s5cmd` beforehand, there is no way for app to prevent the expansion. We urge users to consider escaping from globbing by wrapping the related argument to quotes. Obviously, the escaping method can be different for every shell implementation. 

Fixes #555 