### PR TITLE
command: fix file overriding when download fails (#479)

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -545,12 +545,12 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 		}
 		return err
 	}
-	defer file.Close()
 
 	if c.deleteSource {
 		_ = srcClient.Delete(ctx, srcurl)
 	}
 
+	file.Close()
 	os.Rename(tempurl.Absolute(), dsturl.Absolute())
 
 	msg := log.InfoMessage{

--- a/command/cp.go
+++ b/command/cp.go
@@ -549,7 +549,10 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 		_ = srcClient.Delete(ctx, srcurl)
 	}
 
-	dstClient.Rename(file, dsturl.Absolute())
+	err = dstClient.Rename(file, dsturl.Absolute())
+	if err != nil {
+		return err
+	}
 
 	msg := log.InfoMessage{
 		Operation:   c.op,

--- a/command/cp.go
+++ b/command/cp.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -529,7 +531,7 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 	}
 
 	var tempurl = *dsturl
-	tempurl.Path = tempurl.Path + ".tmp"
+	tempurl.Path = tempurl.Path + strconv.Itoa(rand.Int())
 	file, err := dstClient.Create(tempurl.Absolute())
 	if err != nil {
 		return err

--- a/command/cp.go
+++ b/command/cp.go
@@ -536,9 +536,8 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 	}
 
 	size, err := srcClient.Get(ctx, srcurl, file, c.concurrency, c.partSize)
+	file.Close()
 	if err != nil {
-		// file must be closed before deletion
-		file.Close()
 		dErr := dstClient.Delete(ctx, &url.URL{Path: file.Name(), Type: dsturl.Type})
 		if dErr != nil {
 			printDebug(c.op, dErr, srcurl, dsturl)
@@ -550,7 +549,6 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 		_ = srcClient.Delete(ctx, srcurl)
 	}
 
-	file.Close()
 	dstClient.Rename(file, dsturl.Absolute())
 
 	msg := log.InfoMessage{

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4165,7 +4165,7 @@ func TestLocalFileOverridenWhenDownloadFailed(t *testing.T) {
 
 	result.Assert(t, icmd.Expected{ExitCode: 1})
 
-	// assert local filesystem does not have the inital file
+	// assert initial file is untouched
 	expected := fs.Expected(t, fs.WithFile(filename, content))
 	assert.Assert(t, fs.Equal(workdir.Path(), expected))
 }

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4142,7 +4142,7 @@ func TestDeleteFileWhenDownloadFailed(t *testing.T) {
 }
 
 // Target local file should be overriden only if download completed successfully
-func TestLocalFileOverridenWhenDownloadFailed(t *testing.T){
+func TestLocalFileOverridenWhenDownloadFailed(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -4150,8 +4150,8 @@ func TestLocalFileOverridenWhenDownloadFailed(t *testing.T){
 	createBucket(t, s3client, bucket)
 
 	const (
-		filename   = "testfile1.txt"
-		content    = "preserved content"
+		filename        = "testfile1.txt"
+		content         = "preserved content"
 		expectedContent = "preserved content"
 	)
 

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -223,7 +223,7 @@ func (f *Filesystem) Open(path string) (*os.File, error) {
 	return file, nil
 }
 
-// Create a new temporary file
+// CreateTemp creates a new temporary file
 func (f *Filesystem) CreateTemp(dir, pattern string) (*os.File, error) {
 	if f.dryRun {
 		return &os.File{}, nil

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -223,6 +223,30 @@ func (f *Filesystem) Open(path string) (*os.File, error) {
 	return file, nil
 }
 
+// Create a new temporary file
+func (f *Filesystem) CreateTemp(dir, pattern string) (*os.File, error) {
+	if f.dryRun {
+		return &os.File{}, nil
+	}
+
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	err = file.Chmod(0644)
+	return file, err
+}
+
+// Rename a file
+func (f *Filesystem) Rename(file *os.File, newpath string) error {
+	if f.dryRun {
+		return nil
+	}
+
+	return os.Rename(file.Name(), newpath)
+}
+
 func sendObject(ctx context.Context, obj *Object, ch chan *Object) {
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Resolves #479 
Local files used to be overwritten even if downloads failed.
Solved it by creating a temporary file and renaming it with the original filename after completing the download successfully.