### PR TITLE
Update .goreleaser.yaml to correct archives.replacements deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,18 +16,22 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
     ignore:
       - goos: darwin
         goarch: 386
+      - goos: darwin
+        goarch: ppc64le
+      - goos: windows
+        goarch: ppc64le
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      386: 32bit
-      amd64: 64bit
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
Adds the ppc64le architecture to the .goreleaser.yaml and also fixes the deprecation issue with archives.replacements. See issue: #584 