### PR TITLE
storage/fs: handle os.Rename() error

### DIFF
--- a/storage/fs.go
+++ b/storage/fs.go
@@ -244,7 +244,26 @@ func (f *Filesystem) Rename(file *os.File, newpath string) error {
 		return nil
 	}
 
-	return os.Rename(file.Name(), newpath)
+	err := os.Rename(file.Name(), newpath)
+	if err != nil {
+		// Read the content from the source file
+		data, err := os.ReadFile(file.Name())
+		if err != nil {
+			return err
+		}
+
+		// Write the content to the destination file
+		err = os.WriteFile(newpath, data, 0644)
+		if err != nil {
+			return err
+		}
+
+		// Remove the source file after successfully copying its content
+		if err := os.Remove(file.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func sendObject(ctx context.Context, obj *Object, ch chan *Object) {

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -255,7 +255,7 @@ func (f *Filesystem) Rename(file *os.File, newpath string) error {
 		if err != nil {
 			return err
 		}
-		
+
 		if err := os.Remove(file.Name()); err != nil {
 			return err
 		}

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -246,19 +246,16 @@ func (f *Filesystem) Rename(file *os.File, newpath string) error {
 
 	err := os.Rename(file.Name(), newpath)
 	if err != nil {
-		// Read the content from the source file
 		data, err := os.ReadFile(file.Name())
 		if err != nil {
 			return err
 		}
 
-		// Write the content to the destination file
 		err = os.WriteFile(newpath, data, 0644)
 		if err != nil {
 			return err
 		}
-
-		// Remove the source file after successfully copying its content
+		
 		if err := os.Remove(file.Name()); err != nil {
 			return err
 		}


### PR DESCRIPTION
If `os.Rename()`  fails, creates a copy of the file by using `os.WriteFile()` without renaming the original file, then deletes the initial file.