### PR TITLE
e2e/run: update racy test case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,38 @@
 name: ci
 on: [push, pull_request]
 jobs:
+  build:
+    strategy:
+      matrix:
+        go-version:
+          - 1.19.x
+          - 1.18.x
+          - 1.17.x
+        os:
+          - macos
+          - ubuntu
+          - windows
+
+    name: build (${{ matrix.os }}/go-${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - run: make build
+
   test:
     strategy:
       matrix:
         go-version:
           - 1.19.x
+          - 1.18.x
+          - 1.17.x
         os:
+          - macos
+          - ubuntu
           - windows
 
     name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
@@ -17,4 +43,28 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - run: go test -v -count 100 -run ^TestRunWildcardCountGreaterEqualThanWorkerCount$ ./e2e
+    - run: make test
+
+  qa:
+    strategy:
+      matrix:
+        go-version:
+          - 1.19.x
+        os:
+          - ubuntu
+
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - run: make check-fmt
+    - run: go install github.com/golang/mock/mockgen@v1.6.0
+    - run: make check-codegen
+    - run: make vet
+    - run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.0
+    - run: make staticcheck
+    - run: go install mvdan.cc/unparam@latest
+    - run: make unparam

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,12 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  build:
-    strategy:
-      matrix:
-        go-version:
-          - 1.19.x
-          - 1.18.x
-          - 1.17.x
-        os:
-          - macos
-          - ubuntu
-          - windows
-
-    name: build (${{ matrix.os }}/go-${{ matrix.go-version }})
-    runs-on: ${{ matrix.os }}-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-
-    - run: make build
-
   test:
     strategy:
       matrix:
         go-version:
           - 1.19.x
-          - 1.18.x
-          - 1.17.x
         os:
-          - macos
-          - ubuntu
           - windows
 
     name: test (${{ matrix.os }}/go-${{ matrix.go-version }})
@@ -43,28 +17,4 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - run: make test
-
-  qa:
-    strategy:
-      matrix:
-        go-version:
-          - 1.19.x
-        os:
-          - ubuntu
-
-    runs-on: ${{ matrix.os }}-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-
-    - run: make check-fmt
-    - run: go install github.com/golang/mock/mockgen@v1.6.0
-    - run: make check-codegen
-    - run: make vet
-    - run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.0
-    - run: make staticcheck
-    - run: go install mvdan.cc/unparam@latest
-    - run: make unparam
+    - run: go test -v -count 100 -run ^TestRunWildcardCountGreaterEqualThanWorkerCount$ ./e2e

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -220,9 +220,9 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	putFile(t, s3client, bucket, "file.txt", "content")
 
 	content := []string{
-		"cp s3://" + bucket + "/f*.txt .",
-		"cp s3://" + bucket + "/f*.txt .",
-		"cp s3://" + bucket + "/f*.txt .",
+		"cp s3://" + bucket + "/f*.txt folder1",
+		"cp s3://" + bucket + "/f*.txt folder2",
+		"cp s3://" + bucket + "/f*.txt folder3",
 	}
 	file := fs.NewFile(t, "prefix", fs.WithContent(strings.Join(content, "\n")))
 	defer file.Remove()
@@ -235,10 +235,12 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
+	fmt.Println(result.Stdout())
+
 	assertLines(t, result.Stdout(), map[int]compareFunc{
-		0: equals(`cp s3://%v/file.txt file.txt`, bucket),
-		1: equals(`cp s3://%v/file.txt file.txt`, bucket),
-		2: equals(`cp s3://%v/file.txt file.txt`, bucket),
+		0: equals(`cp s3://%v/file.txt folder1/file.txt`, bucket),
+		1: equals(`cp s3://%v/file.txt folder2/file.txt`, bucket),
+		2: equals(`cp s3://%v/file.txt folder3/file.txt`, bucket),
 	}, sortInput(true))
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{})

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -235,8 +235,6 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
-	fmt.Println(result.Stdout())
-
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: equals(`cp s3://%v/file.txt folder1/file.txt`, bucket),
 		1: equals(`cp s3://%v/file.txt folder2/file.txt`, bucket),


### PR DESCRIPTION
Resolves #602

The `TestRunWildcardCountGreaterEqualThanWorkerCount` test used to download the same file to the same directory concurrently, and it used to cause `Access Denied` errors on Windows systems due to trying to rename a file while downloading a file with the same name at the same time.

Changes are made:
- Changed the download paths in the `TestRunWildcardCountGreaterEqualThanWorkerCount` test.