### PR TITLE
.github/workflows/ci: bump staticcheck to v0.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - run: go install github.com/golang/mock/mockgen@v1.6.0
     - run: make check-codegen
     - run: make vet
-    - run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.0
+    - run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
     - run: make staticcheck
     - run: go install mvdan.cc/unparam@latest
     - run: make unparam


### PR DESCRIPTION
`staticcheck` fails on linux on https://github.com/peak/s5cmd/pull/583, probably due to an older version. Before merging #583 let's update it.
