### PR TITLE
github/dependabot: create security fix PRs only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Create security fix PRs only
+    open-pull-requests-limit: 0
+
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Create security fix PRs only
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Dependabot became annoying very fast. The only way to disable release
updates but allow security fixes is to set open pull request limit
to 0, according to
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
