### PR TITLE
command/pipe: add more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ $ tree
 Will upload all files at given directory to S3 while keeping the folder hierarchy
 of the source.
 
+#### Stream stdin to S3
+You can upload remote objects by piping stdin to `s5cmd`:
+
+    curl https://github.com/peak/s5cmd/ | ./s5cmd pipe s3://bucket/s5cmd.html
+
+Or you can compress the data before uploading:
+
+    tar -cf - file.bin | s5cmd pipe s3://bucket/file.bin.tar
+
 #### Delete an S3 object
 
     s5cmd rm s3://bucket/logs/2020/03/18/file1.gz

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ of the source.
 #### Stream stdin to S3
 You can upload remote objects by piping stdin to `s5cmd`:
 
-    curl https://github.com/peak/s5cmd/ | ./s5cmd pipe s3://bucket/s5cmd.html
+    curl https://github.com/peak/s5cmd/ | s5cmd pipe s3://bucket/s5cmd.html
 
 Or you can compress the data before uploading:
 

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -29,7 +29,7 @@ Examples:
 	01. Stream stdin to an object
 		 > echo "content" | gzip | s5cmd {{.HelpName}} s3://bucket/prefix/object.gz
 	02. Download an object and stream it to a bucket
-		> curl https://github.com/peak/s5cmd/ | ./s5cmd {{.HelpName}} s3://bucket/s5cmd.html
+		> curl https://github.com/peak/s5cmd/ | s5cmd {{.HelpName}} s3://bucket/s5cmd.html
 	03. Compress an object and stream it to a bucket
 		> tar -cf - file.bin | s5cmd {{.HelpName}} s3://bucket/file.bin.tar
 `

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -28,6 +28,10 @@ Options:
 Examples:
 	01. Stream stdin to an object
 		 > echo "content" | gzip | s5cmd {{.HelpName}} s3://bucket/prefix/object.gz
+	02. Download an object and stream it to a bucket
+		> curl https://github.com/peak/s5cmd/ | ./s5cmd {{.HelpName}} s3://bucket/s5cmd.html
+	03. Compress an object and stream it to a bucket
+		> tar -cf - file.bin | s5cmd {{.HelpName}} s3://bucket/file.bin.tar
 `
 
 func NewPipeCommandFlags() []cli.Flag {


### PR DESCRIPTION
- Added an example that shows how to use the `pipe` command to upload remote objects to a bucket.
- Added an example that shows how to use the `pipe` command to compress files before uploading them.
