### PR TITLE
Feat: add minimalist utilities in the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache git make && \
     CGO_ENABLED=0 make build
 
 FROM alpine:3.15
+RUN apk add --no-cache coreutils findutils bash grep jq
 COPY --from=build /s5cmd/s5cmd .
 WORKDIR /aws
 ENTRYPOINT ["/s5cmd"]


### PR DESCRIPTION
Rationale: the existing container image is too barebones to be used in production scenarios.

If you need to do some additional scripting for example for some backup routine (like cleanup, retention, basic filtering either locally or remotely), you have to either add apk packages at runtime or build another container image with the current one as base.

For example, since s5cmd supports json output, one could use `jq` to get and then script to manipulate programmatically the remote s3 objects

The resulting uncopressed image is 31.5MB as compared to current 25.7MB:
![image](https://github.com/peak/s5cmd/assets/11889198/120abd41-428c-4162-8972-83dc9bbd26c3)

