### PR TITLE
cp,pipe: don't omit some of the metadata flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
+## not released yet
+#### Bugfixes
+- Fixed `cp` and `pipe` to not omit some of the metadata flags. ([#657](https://github.com/peak/s5cmd/issues/657))
 
 ## v2.2.1 - 23 Aug 2023
 
 #### Bugfixes
 - Fixed incorrect `s5cmd version` output ([#650](https://github.com/peak/s5cmd/pull/650))
-
 ## v2.2.0 - 21 Aug 2023
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
-## not released yet
+## v2.2.2 - 13 Sep 2023 
+
 #### Bugfixes
 - Fixed `cp` and `pipe` to not omit some of the metadata flags. ([#657](https://github.com/peak/s5cmd/issues/657))
-
 ## v2.2.1 - 23 Aug 2023
 
 #### Bugfixes

--- a/command/cp.go
+++ b/command/cp.go
@@ -689,7 +689,19 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL, ex
 	if err != nil {
 		return err
 	}
+
 	metadata := storage.Metadata{UserDefined: extradata}
+	if c.acl != "" {
+		metadata.ACL = c.acl
+	}
+
+	if c.cacheControl != "" {
+		metadata.CacheControl = c.cacheControl
+	}
+
+	if c.expires != "" {
+		metadata.Expires = c.expires
+	}
 
 	if c.storageClass != "" {
 		metadata.StorageClass = string(c.storageClass)
@@ -707,6 +719,14 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL, ex
 
 	if c.contentDisposition != "" {
 		metadata.ContentDisposition = c.contentDisposition
+	}
+
+	if c.encryptionMethod != "" {
+		metadata.EncryptionMethod = c.encryptionMethod
+	}
+
+	if c.encryptionKeyID != "" {
+		metadata.EncryptionKeyID = c.encryptionKeyID
 	}
 
 	reader := newCountingReaderWriter(file, c.progressbar)
@@ -756,6 +776,18 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL, extradata map
 	}
 
 	metadata := storage.Metadata{UserDefined: extradata}
+	if c.acl != "" {
+		metadata.ACL = c.acl
+	}
+
+	if c.cacheControl != "" {
+		metadata.CacheControl = c.cacheControl
+	}
+
+	if c.expires != "" {
+		metadata.Expires = c.expires
+	}
+
 	if c.storageClass != "" {
 		metadata.StorageClass = string(c.storageClass)
 	}
@@ -767,8 +799,17 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL, extradata map
 	if c.contentEncoding != "" {
 		metadata.ContentEncoding = c.contentEncoding
 	}
+
 	if c.contentDisposition != "" {
 		metadata.ContentDisposition = c.contentDisposition
+	}
+
+	if c.encryptionMethod != "" {
+		metadata.EncryptionMethod = c.encryptionMethod
+	}
+
+	if c.encryptionKeyID != "" {
+		metadata.EncryptionKeyID = c.encryptionKeyID
 	}
 
 	err = c.shouldOverride(ctx, srcurl, dsturl)

--- a/command/cp.go
+++ b/command/cp.go
@@ -691,21 +691,10 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL, ex
 	}
 
 	metadata := storage.Metadata{UserDefined: extradata}
-	if c.acl != "" {
-		metadata.ACL = c.acl
-	}
-
-	if c.cacheControl != "" {
-		metadata.CacheControl = c.cacheControl
-	}
-
-	if c.expires != "" {
-		metadata.Expires = c.expires
-	}
-
-	if c.storageClass != "" {
-		metadata.StorageClass = string(c.storageClass)
-	}
+	metadata.ACL = c.acl
+	metadata.CacheControl = c.cacheControl
+	metadata.Expires = c.expires
+	metadata.StorageClass = string(c.storageClass)
 
 	if c.contentType != "" {
 		metadata.ContentType = c.contentType
@@ -713,21 +702,10 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL, ex
 		metadata.ContentType = guessContentType(file)
 	}
 
-	if c.contentEncoding != "" {
-		metadata.ContentEncoding = c.contentEncoding
-	}
-
-	if c.contentDisposition != "" {
-		metadata.ContentDisposition = c.contentDisposition
-	}
-
-	if c.encryptionMethod != "" {
-		metadata.EncryptionMethod = c.encryptionMethod
-	}
-
-	if c.encryptionKeyID != "" {
-		metadata.EncryptionKeyID = c.encryptionKeyID
-	}
+	metadata.ContentEncoding = c.contentEncoding
+	metadata.ContentDisposition = c.contentDisposition
+	metadata.EncryptionMethod = c.encryptionMethod
+	metadata.EncryptionKeyID = c.encryptionKeyID
 
 	reader := newCountingReaderWriter(file, c.progressbar)
 	err = dstClient.Put(ctx, reader, dsturl, metadata, c.concurrency, c.partSize)
@@ -776,41 +754,15 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL, extradata map
 	}
 
 	metadata := storage.Metadata{UserDefined: extradata}
-	if c.acl != "" {
-		metadata.ACL = c.acl
-	}
-
-	if c.cacheControl != "" {
-		metadata.CacheControl = c.cacheControl
-	}
-
-	if c.expires != "" {
-		metadata.Expires = c.expires
-	}
-
-	if c.storageClass != "" {
-		metadata.StorageClass = string(c.storageClass)
-	}
-
-	if c.contentType != "" {
-		metadata.ContentType = c.contentType
-	}
-
-	if c.contentEncoding != "" {
-		metadata.ContentEncoding = c.contentEncoding
-	}
-
-	if c.contentDisposition != "" {
-		metadata.ContentDisposition = c.contentDisposition
-	}
-
-	if c.encryptionMethod != "" {
-		metadata.EncryptionMethod = c.encryptionMethod
-	}
-
-	if c.encryptionKeyID != "" {
-		metadata.EncryptionKeyID = c.encryptionKeyID
-	}
+	metadata.ACL = c.acl
+	metadata.CacheControl = c.cacheControl
+	metadata.Expires = c.expires
+	metadata.StorageClass = string(c.storageClass)
+	metadata.ContentType = c.contentType
+	metadata.ContentEncoding = c.contentEncoding
+	metadata.ContentDisposition = c.contentDisposition
+	metadata.EncryptionMethod = c.encryptionMethod
+	metadata.EncryptionKeyID = c.encryptionKeyID
 
 	err = c.shouldOverride(ctx, srcurl, dsturl)
 	if err != nil {

--- a/command/cp.go
+++ b/command/cp.go
@@ -690,22 +690,23 @@ func (c Copy) doUpload(ctx context.Context, srcurl *url.URL, dsturl *url.URL, ex
 		return err
 	}
 
-	metadata := storage.Metadata{UserDefined: extradata}
-	metadata.ACL = c.acl
-	metadata.CacheControl = c.cacheControl
-	metadata.Expires = c.expires
-	metadata.StorageClass = string(c.storageClass)
+	metadata := storage.Metadata{
+		UserDefined:        extradata,
+		ACL:                c.acl,
+		CacheControl:       c.cacheControl,
+		Expires:            c.expires,
+		StorageClass:       string(c.storageClass),
+		ContentEncoding:    c.contentEncoding,
+		ContentDisposition: c.contentDisposition,
+		EncryptionMethod:   c.encryptionMethod,
+		EncryptionKeyID:    c.encryptionKeyID,
+	}
 
 	if c.contentType != "" {
 		metadata.ContentType = c.contentType
 	} else {
 		metadata.ContentType = guessContentType(file)
 	}
-
-	metadata.ContentEncoding = c.contentEncoding
-	metadata.ContentDisposition = c.contentDisposition
-	metadata.EncryptionMethod = c.encryptionMethod
-	metadata.EncryptionKeyID = c.encryptionKeyID
 
 	reader := newCountingReaderWriter(file, c.progressbar)
 	err = dstClient.Put(ctx, reader, dsturl, metadata, c.concurrency, c.partSize)
@@ -753,16 +754,18 @@ func (c Copy) doCopy(ctx context.Context, srcurl, dsturl *url.URL, extradata map
 		return err
 	}
 
-	metadata := storage.Metadata{UserDefined: extradata}
-	metadata.ACL = c.acl
-	metadata.CacheControl = c.cacheControl
-	metadata.Expires = c.expires
-	metadata.StorageClass = string(c.storageClass)
-	metadata.ContentType = c.contentType
-	metadata.ContentEncoding = c.contentEncoding
-	metadata.ContentDisposition = c.contentDisposition
-	metadata.EncryptionMethod = c.encryptionMethod
-	metadata.EncryptionKeyID = c.encryptionKeyID
+	metadata := storage.Metadata{
+		UserDefined:        extradata,
+		ACL:                c.acl,
+		CacheControl:       c.cacheControl,
+		Expires:            c.expires,
+		StorageClass:       string(c.storageClass),
+		ContentType:        c.contentType,
+		ContentEncoding:    c.contentEncoding,
+		ContentDisposition: c.contentDisposition,
+		EncryptionMethod:   c.encryptionMethod,
+		EncryptionKeyID:    c.encryptionKeyID,
+	}
 
 	err = c.shouldOverride(ctx, srcurl, dsturl)
 	if err != nil {

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -221,20 +221,23 @@ func (c Pipe) Run(ctx context.Context) error {
 		return err
 	}
 
-	metadata := storage.Metadata{UserDefined: c.metadata}
-	metadata.ACL = c.acl
-	metadata.CacheControl = c.cacheControl
-	metadata.Expires = c.expires
-	metadata.StorageClass = string(c.storageClass)
+	metadata := storage.Metadata{
+		UserDefined:        c.metadata,
+		ACL:                c.acl,
+		CacheControl:       c.cacheControl,
+		Expires:            c.expires,
+		StorageClass:       string(c.storageClass),
+		ContentEncoding:    c.contentEncoding,
+		ContentDisposition: c.contentDisposition,
+		EncryptionMethod:   c.encryptionMethod,
+		EncryptionKeyID:    c.encryptionKeyID,
+	}
+
 	if c.contentType != "" {
 		metadata.ContentType = c.contentType
 	} else {
 		metadata.ContentType = guessContentTypeByExtension(c.dst)
 	}
-	metadata.ContentEncoding = c.contentEncoding
-	metadata.ContentDisposition = c.contentDisposition
-	metadata.EncryptionMethod = c.encryptionMethod
-	metadata.EncryptionKeyID = c.encryptionKeyID
 
 	err = client.Put(ctx, &stdin{file: os.Stdin}, c.dst, metadata, c.concurrency, c.partSize)
 	if err != nil {

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -222,43 +222,19 @@ func (c Pipe) Run(ctx context.Context) error {
 	}
 
 	metadata := storage.Metadata{UserDefined: c.metadata}
-	if c.acl != "" {
-		metadata.ACL = c.acl
-	}
-
-	if c.cacheControl != "" {
-		metadata.CacheControl = c.cacheControl
-	}
-
-	if c.expires != "" {
-		metadata.Expires = c.expires
-	}
-
-	if c.storageClass != "" {
-		metadata.StorageClass = string(c.storageClass)
-	}
-
+	metadata.ACL = c.acl
+	metadata.CacheControl = c.cacheControl
+	metadata.Expires = c.expires
+	metadata.StorageClass = string(c.storageClass)
 	if c.contentType != "" {
 		metadata.ContentType = c.contentType
 	} else {
 		metadata.ContentType = guessContentTypeByExtension(c.dst)
 	}
-
-	if c.contentEncoding != "" {
-		metadata.ContentEncoding = c.contentEncoding
-	}
-
-	if c.contentDisposition != "" {
-		metadata.ContentDisposition = c.contentDisposition
-	}
-
-	if c.encryptionMethod != "" {
-		metadata.EncryptionMethod = c.encryptionMethod
-	}
-
-	if c.encryptionKeyID != "" {
-		metadata.EncryptionKeyID = c.encryptionKeyID
-	}
+	metadata.ContentEncoding = c.contentEncoding
+	metadata.ContentDisposition = c.contentDisposition
+	metadata.EncryptionMethod = c.encryptionMethod
+	metadata.EncryptionKeyID = c.encryptionKeyID
 
 	err = client.Put(ctx, &stdin{file: os.Stdin}, c.dst, metadata, c.concurrency, c.partSize)
 	if err != nil {

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -222,6 +222,18 @@ func (c Pipe) Run(ctx context.Context) error {
 	}
 
 	metadata := storage.Metadata{UserDefined: c.metadata}
+	if c.acl != "" {
+		metadata.ACL = c.acl
+	}
+
+	if c.cacheControl != "" {
+		metadata.CacheControl = c.cacheControl
+	}
+
+	if c.expires != "" {
+		metadata.Expires = c.expires
+	}
+
 	if c.storageClass != "" {
 		metadata.StorageClass = string(c.storageClass)
 	}
@@ -235,8 +247,17 @@ func (c Pipe) Run(ctx context.Context) error {
 	if c.contentEncoding != "" {
 		metadata.ContentEncoding = c.contentEncoding
 	}
+
 	if c.contentDisposition != "" {
 		metadata.ContentDisposition = c.contentDisposition
+	}
+
+	if c.encryptionMethod != "" {
+		metadata.EncryptionMethod = c.encryptionMethod
+	}
+
+	if c.encryptionKeyID != "" {
+		metadata.EncryptionKeyID = c.encryptionKeyID
 	}
 
 	err = client.Put(ctx, &stdin{file: os.Stdin}, c.dst, metadata, c.concurrency, c.partSize)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -767,7 +767,9 @@ func TestCopySingleFileToS3WithAllMetadataFlags(t *testing.T) {
 		"--content-encoding", ContentEncoding,
 		"--sse", EncryptionMethod,
 		"--sse-kms-key-id", EncryptionKeyID,
-		srcpath, dstpath)
+		srcpath, dstpath,
+	)
+
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Success)
@@ -785,44 +787,6 @@ func TestCopySingleFileToS3WithAllMetadataFlags(t *testing.T) {
 		ensureEncryptionMethod(EncryptionMethod),
 		ensureEncryptionKeyID(EncryptionKeyID),
 	))
-
-}
-
-// NOTE: This test needs an implementation of the
-// `ACL` feature in gofakes3.
-func TestCopySingleFileToS3WithACLFlag(t *testing.T) {
-	t.Skip()
-
-	t.Parallel()
-
-	s3client, s5cmd := setup(t)
-
-	bucket := s3BucketFromTestName(t)
-
-	createBucket(t, s3client, bucket)
-
-	const (
-		filename = "index"
-		content  = `testfilecontent`
-		acl      = "public-read"
-	)
-
-	workdir := fs.NewDir(t, bucket, fs.WithFile(filename, content))
-	defer workdir.Remove()
-
-	srcpath := workdir.Join(filename)
-	dstpath := fmt.Sprintf("s3://%v/", bucket)
-
-	srcpath = filepath.ToSlash(srcpath)
-	cmd := s5cmd("cp", "--acl", acl, srcpath, dstpath)
-	result := icmd.RunCmd(cmd)
-
-	result.Assert(t, icmd.Success)
-
-	expected := fs.Expected(t, fs.WithFile(filename, content))
-	assert.Assert(t, fs.Equal(workdir.Path(), expected))
-
-	assert.Assert(t, ensureS3Object(s3client, bucket, filename, content, ensureACL(acl)))
 
 }
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -25,6 +25,7 @@ package e2e
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -720,6 +721,111 @@ func TestCopySingleFileToS3(t *testing.T) {
 	assert.Assert(t, ensureS3Object(s3client, bucket, filename, content, ensureContentType(expectedContentType), ensureContentDisposition(expectedContentDisposition)))
 }
 
+func TestCopySingleFileToS3WithAllMetadataFlags(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+
+	createBucket(t, s3client, bucket)
+
+	const (
+		filename           = "index"
+		content            = `testfilecontent`
+		cacheControl       = "public, max-age=3600"
+		expires            = "2025-01-01T00:00:00Z"
+		storageClass       = "STANDARD_IA"
+		ContentType        = "text/html; charset=utf-8"
+		ContentDisposition = "inline"
+		ContentEncoding    = "utf-8"
+		EncryptionMethod   = "aws:kms"
+		EncryptionKeyID    = "1234abcd-12ab-34cd-56ef-1234567890ab"
+	)
+
+	// expected expires flag is the parsed version of the date in RFC3339 format
+	parsedTime, err := time.Parse(time.RFC3339, expires)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedExpires := parsedTime.Format(http.TimeFormat)
+
+	workdir := fs.NewDir(t, bucket, fs.WithFile(filename, content))
+	defer workdir.Remove()
+
+	srcpath := workdir.Join(filename)
+	dstpath := fmt.Sprintf("s3://%v/", bucket)
+
+	srcpath = filepath.ToSlash(srcpath)
+	cmd := s5cmd("cp",
+		"--cache-control", cacheControl,
+		"--expires", expires,
+		"--storage-class", storageClass,
+		"--content-type", ContentType,
+		"--content-disposition", ContentDisposition,
+		"--content-encoding", ContentEncoding,
+		"--sse", EncryptionMethod,
+		"--sse-kms-key-id", EncryptionKeyID,
+		srcpath, dstpath)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	expected := fs.Expected(t, fs.WithFile(filename, content))
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	assert.Assert(t, ensureS3Object(s3client, bucket, filename, content,
+		ensureExpires(expectedExpires),
+		ensureCacheControl(cacheControl),
+		ensureStorageClass(storageClass),
+		ensureContentType(ContentType),
+		ensureContentDisposition(ContentDisposition),
+		ensureContentEncoding(ContentEncoding),
+		ensureEncryptionMethod(EncryptionMethod),
+		ensureEncryptionKeyID(EncryptionKeyID),
+	))
+
+}
+
+// NOTE: This test needs an implementation of the
+// `ACL` feature in gofakes3.
+func TestCopySingleFileToS3WithACLFlag(t *testing.T) {
+	t.Skip()
+
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+
+	createBucket(t, s3client, bucket)
+
+	const (
+		filename = "index"
+		content  = `testfilecontent`
+		acl      = "public-read"
+	)
+
+	workdir := fs.NewDir(t, bucket, fs.WithFile(filename, content))
+	defer workdir.Remove()
+
+	srcpath := workdir.Join(filename)
+	dstpath := fmt.Sprintf("s3://%v/", bucket)
+
+	srcpath = filepath.ToSlash(srcpath)
+	cmd := s5cmd("cp", "--acl", acl, srcpath, dstpath)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	expected := fs.Expected(t, fs.WithFile(filename, content))
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	assert.Assert(t, ensureS3Object(s3client, bucket, filename, content, ensureACL(acl)))
+
+}
+
 // cp dir/file s3://bucket/ --metadata key1=val1 --metadata key2=val2 ...
 func TestCopySingleFileToS3WithArbitraryMetadata(t *testing.T) {
 	t.Parallel()
@@ -800,10 +906,11 @@ func TestCopyS3ToS3WithArbitraryMetadata(t *testing.T) {
 		"Key1": aws.String("foo"),
 		"Key2": aws.String("bar"),
 	}
+
 	srcpath := fmt.Sprintf("s3://%v/%v", bucket, filename)
 	dstpath := fmt.Sprintf("s3://%v/%v_cp", bucket, filename)
 
-	putFileWithMetadata(t, s3client, bucket, filename, content, srcmetadata)
+	putFile(t, s3client, bucket, filename, content, putArbitraryMetadata(srcmetadata))
 	cmd := s5cmd("cp", "--metadata", foo, "--metadata", bar, srcpath, dstpath)
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
-	github.com/igungor/gofakes3 v0.0.14
+	github.com/igungor/gofakes3 v0.0.15
 	github.com/karrick/godirwalk v1.15.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lanrat/extsort v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
-github.com/igungor/gofakes3 v0.0.14 h1:jpKujPDFe6iF3rJ34AyafvK7+LatbSbjRTnmBVPnsuY=
-github.com/igungor/gofakes3 v0.0.14/go.mod h1:+rwAKRO9RTGCIeE8SRvRPLSj7PVhaMBLlm1zPXzu7Cs=
+github.com/igungor/gofakes3 v0.0.15 h1:/57KiuC2Nc0Heh1cjnTOe6mWrDNxIr8kfF7xgah55OA=
+github.com/igungor/gofakes3 v0.0.15/go.mod h1:+rwAKRO9RTGCIeE8SRvRPLSj7PVhaMBLlm1zPXzu7Cs=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -819,6 +819,7 @@ func (s *S3) Put(
 	if storageClass != "" {
 		input.StorageClass = aws.String(storageClass)
 	}
+
 	acl := metadata.ACL
 	if acl != "" {
 		input.ACL = aws.String(acl)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -225,10 +225,10 @@ type Metadata struct {
 	Expires            string
 	StorageClass       string
 	ContentType        string
+	ContentEncoding    string
 	ContentDisposition string
 	EncryptionMethod   string
 	EncryptionKeyID    string
-	ContentEncoding    string
 
 	UserDefined map[string]string
 }

--- a/vendor/github.com/igungor/gofakes3/gofakes3.go
+++ b/vendor/github.com/igungor/gofakes3/gofakes3.go
@@ -1039,10 +1039,13 @@ func metadataHeaders(headers map[string][]string, at time.Time, sizeLimit int) (
 		if strings.HasPrefix(hk, "X-Amz-") ||
 			hk == "Content-Type" ||
 			hk == "Content-Disposition" ||
-			hk == "Content-Encoding" {
+			hk == "Content-Encoding" ||
+			hk == "Expires" ||
+			hk == "Cache-Control" {
 			meta[hk] = hv[0]
 		}
 	}
+
 	meta["Last-Modified"] = formatHeaderTime(at)
 
 	if sizeLimit > 0 && metadataSize(meta) > sizeLimit {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/hashicorp/go-multierror
 # github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 ## explicit
 github.com/iancoleman/strcase
-# github.com/igungor/gofakes3 v0.0.14
+# github.com/igungor/gofakes3 v0.0.15
 ## explicit; go 1.13
 github.com/igungor/gofakes3
 github.com/igungor/gofakes3/backend/s3bolt


### PR DESCRIPTION
#657 mentioned that `acl` flag was broken in `v2.2.1`. After looking at the issue, it was discovered that not only the `acl` flag was broken, there are couple of more flags that were being omitted during the mentioned commands, which all of them caused by this faulty [PR](https://github.com/peak/s5cmd/pull/621). 

Resolves #657.