### PR TITLE
dockerfile: use Alpine 3.18 as base for release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git make && \
     cd /s5cmd/ && \
     CGO_ENABLED=0 make build
 
-FROM alpine:3.15
+FROM alpine:3.18
 COPY --from=build /s5cmd/s5cmd .
 WORKDIR /aws
 ENTRYPOINT ["/s5cmd"]


### PR DESCRIPTION
Alpine 3.15 will be EOL on 2023-11-01 ([source](https://alpinelinux.org/releases/)). Releases happen quite frequently, but I wanted to propose updating the base image to Alpine 3.18 (which will be supported until 2025-05-09) so the EOL of 3.15 is anticipated for future releases.