### PR TITLE
add `--log-stderr`: write log output to stderr

### DIFF
--- a/command/app.go
+++ b/command/app.go
@@ -59,6 +59,10 @@ var app = &cli.App{
 			Usage: "log level: (trace, debug, info, error)",
 		},
 		&cli.BoolFlag{
+			Name:  "log-stderr",
+			Usage: "direct log output to stderr instead of stdout",
+		},
+		&cli.BoolFlag{
 			Name:  "install-completion",
 			Usage: "get completion installation instructions for your shell (only available for bash, pwsh, and zsh)",
 		},
@@ -96,10 +100,11 @@ var app = &cli.App{
 		workerCount := c.Int("numworkers")
 		printJSON := c.Bool("json")
 		logLevel := c.String("log")
+		logStderr := c.Bool("log-stderr")
 		isStat := c.Bool("stat")
 		endpointURL := c.String("endpoint-url")
 
-		log.Init(logLevel, printJSON)
+		log.Init(logLevel, printJSON, logStderr)
 		parallel.Init(workerCount)
 
 		if retryCount < 0 {

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -393,7 +393,7 @@ func TestS3ListContextCancelled(t *testing.T) {
 }
 
 func TestS3Retry(t *testing.T) {
-	log.Init("debug", false)
+	log.Init("debug", false, false)
 
 	testcases := []struct {
 		name          string
@@ -576,7 +576,7 @@ func TestS3Retry(t *testing.T) {
 }
 
 func TestS3RetryOnNoSuchUpload(t *testing.T) {
-	log.Init("debug", false)
+	log.Init("debug", false, false)
 
 	noSuchUploadError := awserr.New(s3.ErrCodeNoSuchUpload, "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed. status code: 404, request id: PJXXXXX, host id: HOSTIDXX", nil)
 	testcases := []struct {
@@ -936,7 +936,7 @@ func TestS3listObjectsV2(t *testing.T) {
 }
 
 func TestSessionCreateAndCachingWithDifferentBuckets(t *testing.T) {
-	log.Init("error", false)
+	log.Init("error", false, false)
 	testcases := []struct {
 		bucket         string
 		alreadyCreated bool // sessions should not be created again if they already have been created before
@@ -1077,7 +1077,7 @@ func TestSessionAutoRegionValidateCredentials(t *testing.T) {
 }
 
 func TestSessionAutoRegion(t *testing.T) {
-	log.Init("error", false)
+	log.Init("error", false, false)
 
 	unitSession := func() *session.Session {
 		return session.Must(session.NewSession(&aws.Config{


### PR DESCRIPTION
Especially if you're using `s5cmd cat`, this flag lets you see log output even when redirecting stdout.