### PR TITLE
fix: renew the session token when the token expires

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1339,11 +1339,6 @@ func newCustomRetryer(sc *SessionCache, maxRetries int) *customRetryer {
 // ShouldRetry overrides SDK's built in DefaultRetryer, adding custom retry
 // logics that are not included in the SDK.
 func (c *customRetryer) ShouldRetry(req *request.Request) bool {
-	log.Error(log.ErrorMessage{
-		Command: "retrier",
-		Err:     req.Error.Error(),
-	})
-
 	shouldRetry := errHasCode(req.Error, "InternalError") || errHasCode(req.Error, "RequestTimeTooSkewed") || errHasCode(req.Error, "SlowDown") || strings.Contains(req.Error.Error(), "connection reset") || strings.Contains(req.Error.Error(), "connection timed out") || errHasCode(req.Error, "ExpiredToken") || errHasCode(req.Error, "ExpiredTokenException")
 
 	if errHasCode(req.Error, "ExpiredToken") || errHasCode(req.Error, "ExpiredTokenException") {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1237,7 +1237,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 
 	awsCfg.Retryer = newCustomRetryer(sc, opts.MaxRetries)
 
-	useSharedConfig := session.SharedConfigDisable
+	useSharedConfig := session.SharedConfigEnable
 	{
 		// Reverse of what the SDK does: if AWS_SDK_LOAD_CONFIG is 0 (or a
 		// falsy value) disable shared configs

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -489,12 +489,12 @@ func TestS3Retry(t *testing.T) {
 		{
 			name:          "ExpiredToken",
 			err:           awserr.New("ExpiredToken", "expired token", nil),
-			expectedRetry: 0,
+			expectedRetry: 5,
 		},
 		{
 			name:          "ExpiredTokenException",
 			err:           awserr.New("ExpiredTokenException", "expired token exception", nil),
-			expectedRetry: 0,
+			expectedRetry: 5,
 		},
 
 		// Invalid Token errors

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -97,7 +97,7 @@ func TestNewSessionPathStyle(t *testing.T) {
 }
 
 func TestNewSessionWithRegionSetViaEnv(t *testing.T) {
-	globalSessionCache.clear()
+	globalSessionCache.Clear()
 
 	const expectedRegion = "us-west-2"
 
@@ -116,7 +116,7 @@ func TestNewSessionWithRegionSetViaEnv(t *testing.T) {
 }
 
 func TestNewSessionWithNoSignRequest(t *testing.T) {
-	globalSessionCache.clear()
+	globalSessionCache.Clear()
 
 	sess, err := globalSessionCache.newSession(context.Background(), Options{
 		NoSignRequest: true,
@@ -190,7 +190,7 @@ aws_secret_access_key = p2_profile_access_key`
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			globalSessionCache.clear()
+			globalSessionCache.Clear()
 			sess, err := globalSessionCache.newSession(context.Background(), Options{
 				Profile:        tc.profileName,
 				CredentialFile: tc.fileName,
@@ -538,8 +538,12 @@ func TestS3Retry(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			sessionCache := &SessionCache{
+				sessions: map[Options]*session.Session{},
+			}
+
 			sess := unit.Session
-			sess.Config.Retryer = newCustomRetryer(expectedRetry)
+			sess.Config.Retryer = newCustomRetryer(sessionCache, expectedRetry)
 
 			mockAPI := s3.New(sess)
 			mockS3 := &S3{
@@ -1041,7 +1045,7 @@ func TestSessionRegionDetection(t *testing.T) {
 				opts.bucket = tc.bucket
 			}
 
-			globalSessionCache.clear()
+			globalSessionCache.Clear()
 
 			sess, err := globalSessionCache.newSession(context.Background(), opts)
 			if err != nil {
@@ -1241,7 +1245,7 @@ func TestAWSLogLevel(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			globalSessionCache.clear()
+			globalSessionCache.Clear()
 			sess, err := globalSessionCache.newSession(context.Background(), Options{
 				LogLevel: log.LevelFromString(tc.level),
 			})


### PR DESCRIPTION
This PR fix https://github.com/peak/s5cmd/issues/678

In a Kubernetes context, when running a very long process, we can easily fall into the `ExpiredToken` error. In order to not introduce any performance degradation, I propose to keep to global variable caching the session token but clear it when catching this specific error. The session will be renewed by reading again the projected volume `/var/run/secrets/eks.amazonaws.com/serviceaccount/token`.