### PR TITLE
Add max delete option

### DIFF
--- a/command/sync.go
+++ b/command/sync.go
@@ -77,6 +77,11 @@ func NewSyncCommandFlags() []cli.Flag {
 			Name:  "delete",
 			Usage: "delete objects in destination but not in source",
 		},
+		&cli.IntFlag{
+			Name:  "max-delete",
+			Usage: "don't delete more than NUM files",
+			Value: -1,
+		},
 		&cli.BoolFlag{
 			Name:  "size-only",
 			Usage: "make size of object only criteria to decide whether an object should be synced",
@@ -129,6 +134,7 @@ type Sync struct {
 
 	// flags
 	delete      bool
+	maxDelete   int
 	sizeOnly    bool
 	exitOnError bool
 
@@ -153,6 +159,7 @@ func NewSync(c *cli.Context) Sync {
 
 		// flags
 		delete:      c.Bool("delete"),
+		maxDelete:   c.Int("max-delete"),
 		sizeOnly:    c.Bool("size-only"),
 		exitOnError: c.Bool("exit-on-error"),
 
@@ -509,6 +516,10 @@ func (s Sync) planRun(
 			}
 
 			if len(dstURLs) == 0 {
+				return
+			}
+			if len(dstURLs) >= s.maxDelete && s.maxDelete >= 0 {
+				fmt.Printf("Not deleting due %d being higher than maximum delete limit\n", len(dstURLs))
 				return
 			}
 

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -2749,3 +2749,196 @@ func TestSyncS3ObjectsIntoAnotherBucketWithIncludeFilters(t *testing.T) {
 		assertError(t, err, errS3NoSuchKey)
 	}
 }
+
+// sync --delete --max-delete 4 folder/ s3://bucket/
+// max-delete is higher than the number of files to delete, so deletion proceeds.
+func TestSyncLocalToS3BucketWithDeleteAndMaxDeleteAllowsDeletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	// ensure source is older.
+	folderLayout := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file", fs.WithTimestamps(now.Add(-time.Minute), now.Add(-time.Minute))),
+	}
+
+	workdir := fs.NewDir(t, "somedir", folderLayout...)
+	defer workdir.Remove()
+
+	s3Content := map[string]string{
+		"readme.md":    "D: this is a readme file",
+		"dir/main.py":  "D: this is a python file",
+		"testfile.txt": "D: this is a test file",
+	}
+
+	for filename, content := range s3Content {
+		putFile(t, s3client, bucket, filename, content)
+	}
+
+	src := fmt.Sprintf("%v/", workdir.Path())
+	src = filepath.ToSlash(src)
+	dst := fmt.Sprintf("s3://%v/", bucket)
+
+	// 3 files to delete, max-delete is 4 → deletion should proceed
+	cmd := s5cmd("sync", "--delete", "--max-delete", "4", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %vcontributing.md %vcontributing.md`, src, dst),
+		1: equals(`rm %vdir/main.py`, dst),
+		2: equals(`rm %vreadme.md`, dst),
+		3: equals(`rm %vtestfile.txt`, dst),
+	}, sortInput(true))
+
+	// assert local filesystem
+	expectedFiles := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file"),
+	}
+	expected := fs.Expected(t, expectedFiles...)
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	expectedS3Content := map[string]string{
+		"contributing.md": "S: this is a readme file",
+	}
+
+	// assert s3 objects
+	for key, content := range expectedS3Content {
+		assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
+	}
+
+	// assert s3 objects should be deleted.
+	for key, content := range s3Content {
+		err := ensureS3Object(s3client, bucket, key, content)
+		if err == nil {
+			t.Errorf("File %v is not deleted from remote : %v\n", key, err)
+		}
+	}
+}
+
+// sync --delete --max-delete 3 folder/ s3://bucket/
+// max-delete equals the number of files to delete, so deletion is skipped.
+func TestSyncLocalToS3BucketWithDeleteAndMaxDeletePreventsExactDeletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	// ensure source is older.
+	folderLayout := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file", fs.WithTimestamps(now.Add(-time.Minute), now.Add(-time.Minute))),
+	}
+
+	workdir := fs.NewDir(t, "somedir", folderLayout...)
+	defer workdir.Remove()
+
+	s3Content := map[string]string{
+		"readme.md":    "D: this is a readme file",
+		"dir/main.py":  "D: this is a python file",
+		"testfile.txt": "D: this is a test file",
+	}
+
+	for filename, content := range s3Content {
+		putFile(t, s3client, bucket, filename, content)
+	}
+
+	src := fmt.Sprintf("%v/", workdir.Path())
+	src = filepath.ToSlash(src)
+	dst := fmt.Sprintf("s3://%v/", bucket)
+
+	// 3 files to delete, max-delete is 3 → deletion should be skipped (3 >= 3)
+	cmd := s5cmd("sync", "--delete", "--max-delete", "3", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	// only copy should happen, no rm operations; max-delete message printed
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`Not deleting due 3 being higher than maximum delete limit`),
+		1: equals(`cp %vcontributing.md %vcontributing.md`, src, dst),
+	}, sortInput(true))
+
+	// assert local filesystem unchanged
+	expectedFiles := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file"),
+	}
+	expected := fs.Expected(t, expectedFiles...)
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	// assert s3 objects that were in destination should still exist (not deleted)
+	for key, content := range s3Content {
+		assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
+	}
+
+	// assert copied object
+	assert.Assert(t, ensureS3Object(s3client, bucket, "contributing.md", "S: this is a readme file"))
+}
+
+// sync --delete --max-delete 2 folder/ s3://bucket/
+// max-delete is lower than the number of files to delete, so deletion is skipped.
+func TestSyncLocalToS3BucketWithDeleteAndMaxDeletePreventsOverLimitDeletion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	// ensure source is older.
+	folderLayout := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file", fs.WithTimestamps(now.Add(-time.Minute), now.Add(-time.Minute))),
+	}
+
+	workdir := fs.NewDir(t, "somedir", folderLayout...)
+	defer workdir.Remove()
+
+	s3Content := map[string]string{
+		"readme.md":    "D: this is a readme file",
+		"dir/main.py":  "D: this is a python file",
+		"testfile.txt": "D: this is a test file",
+	}
+
+	for filename, content := range s3Content {
+		putFile(t, s3client, bucket, filename, content)
+	}
+
+	src := fmt.Sprintf("%v/", workdir.Path())
+	src = filepath.ToSlash(src)
+	dst := fmt.Sprintf("s3://%v/", bucket)
+
+	// 3 files to delete, max-delete is 2 → deletion should be skipped (3 >= 2)
+	cmd := s5cmd("sync", "--delete", "--max-delete", "2", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	// only copy should happen, no rm operations; max-delete message printed
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`Not deleting due 3 being higher than maximum delete limit`),
+		1: equals(`cp %vcontributing.md %vcontributing.md`, src, dst),
+	}, sortInput(true))
+
+	// assert local filesystem unchanged
+	expectedFiles := []fs.PathOp{
+		fs.WithFile("contributing.md", "S: this is a readme file"),
+	}
+	expected := fs.Expected(t, expectedFiles...)
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	// assert s3 objects that were in destination should still exist (not deleted)
+	for key, content := range s3Content {
+		assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
+	}
+
+	// assert copied object
+	assert.Assert(t, ensureS3Object(s3client, bucket, "contributing.md", "S: this is a readme file"))
+}


### PR DESCRIPTION
In reviewing options to fix the issue where errors deleted all files in the destination, I thought that having a maximum delete option similar to what rysnc has would have also been an nice option. So here it is.

Sync test of test data set:

```
$ ./s5cmd --endpoint-url='https://objects.gec.im sync --no-follow-symlinks --delete 's3://test-jcoleman/*' ~/test/
cp s3://test-jcoleman/test-dir-1/test-file-13 /home/grmrgecko/test/test-dir-1/test-file-13
cp s3://test-jcoleman/test-dir-1/test-file-10 /home/grmrgecko/test/test-dir-1/test-file-10
cp s3://test-jcoleman/test-dir-1/test-file-14 /home/grmrgecko/test/test-dir-1/test-file-14
cp s3://test-jcoleman/test-dir-1/test-file-15 /home/grmrgecko/test/test-dir-1/test-file-15
cp s3://test-jcoleman/test-dir-1/test-file-11 /home/grmrgecko/test/test-dir-1/test-file-11
cp s3://test-jcoleman/test-dir-1/test-file-19 /home/grmrgecko/test/test-dir-1/test-file-19
cp s3://test-jcoleman/test-dir-1/test-file-22 /home/grmrgecko/test/test-dir-1/test-file-22
cp s3://test-jcoleman/test-dir-2/test-file-12 /home/grmrgecko/test/test-dir-2/test-file-12
cp s3://test-jcoleman/test-dir-1/test-file-6 /home/grmrgecko/test/test-dir-1/test-file-6
cp s3://test-jcoleman/test-dir-1/test-file-21 /home/grmrgecko/test/test-dir-1/test-file-21
cp s3://test-jcoleman/test-dir-2/test-file-11 /home/grmrgecko/test/test-dir-2/test-file-11
cp s3://test-jcoleman/test-dir-1/test-file-3 /home/grmrgecko/test/test-dir-1/test-file-3
cp s3://test-jcoleman/test-dir-1/test-file-9 /home/grmrgecko/test/test-dir-1/test-file-9
cp s3://test-jcoleman/test-dir-2/test-file-1 /home/grmrgecko/test/test-dir-2/test-file-1
cp s3://test-jcoleman/test-dir-1/test-file-20 /home/grmrgecko/test/test-dir-1/test-file-20
cp s3://test-jcoleman/test-dir-1/test-file-18 /home/grmrgecko/test/test-dir-1/test-file-18
cp s3://test-jcoleman/test-dir-1/test-file-16 /home/grmrgecko/test/test-dir-1/test-file-16
cp s3://test-jcoleman/test-dir-1/test-file-7 /home/grmrgecko/test/test-dir-1/test-file-7
cp s3://test-jcoleman/test-dir-2/test-file-15 /home/grmrgecko/test/test-dir-2/test-file-15
cp s3://test-jcoleman/test-dir-2/test-file-4 /home/grmrgecko/test/test-dir-2/test-file-4
cp s3://test-jcoleman/test-dir-2/test-file-13 /home/grmrgecko/test/test-dir-2/test-file-13
cp s3://test-jcoleman/test-dir-2/test-file-20 /home/grmrgecko/test/test-dir-2/test-file-20
cp s3://test-jcoleman/test-dir-2/test-file-16 /home/grmrgecko/test/test-dir-2/test-file-16
cp s3://test-jcoleman/test-dir-3/test-file-14 /home/grmrgecko/test/test-dir-3/test-file-14
cp s3://test-jcoleman/test-dir-2/test-file-8 /home/grmrgecko/test/test-dir-2/test-file-8
cp s3://test-jcoleman/test-dir-2/test-file-19 /home/grmrgecko/test/test-dir-2/test-file-19
cp s3://test-jcoleman/test-dir-3/test-file-15 /home/grmrgecko/test/test-dir-3/test-file-15
cp s3://test-jcoleman/test-dir-2/test-file-21 /home/grmrgecko/test/test-dir-2/test-file-21
cp s3://test-jcoleman/test-dir-3/test-file-5 /home/grmrgecko/test/test-dir-3/test-file-5
cp s3://test-jcoleman/test-dir-3/test-file-16 /home/grmrgecko/test/test-dir-3/test-file-16
cp s3://test-jcoleman/test-dir-2/test-file-3 /home/grmrgecko/test/test-dir-2/test-file-3
cp s3://test-jcoleman/test-dir-3/test-file-10 /home/grmrgecko/test/test-dir-3/test-file-10
cp s3://test-jcoleman/test-dir-2/test-file-7 /home/grmrgecko/test/test-dir-2/test-file-7
cp s3://test-jcoleman/test-dir-3/test-file-1 /home/grmrgecko/test/test-dir-3/test-file-1
cp s3://test-jcoleman/test-dir-2/test-file-6 /home/grmrgecko/test/test-dir-2/test-file-6
cp s3://test-jcoleman/test-dir-3/test-file-12 /home/grmrgecko/test/test-dir-3/test-file-12
cp s3://test-jcoleman/test-dir-3/test-file-3 /home/grmrgecko/test/test-dir-3/test-file-3
cp s3://test-jcoleman/test-file-3 /home/grmrgecko/test/test-file-3
cp s3://test-jcoleman/test-dir-3/test-file-22 /home/grmrgecko/test/test-dir-3/test-file-22
cp s3://test-jcoleman/test-dir-3/test-file-20 /home/grmrgecko/test/test-dir-3/test-file-20
cp s3://test-jcoleman/test-dir-3/test-file-2 /home/grmrgecko/test/test-dir-3/test-file-2
cp s3://test-jcoleman/test-dir-3/test-file-9 /home/grmrgecko/test/test-dir-3/test-file-9
cp s3://test-jcoleman/test-dir-3/test-file-18 /home/grmrgecko/test/test-dir-3/test-file-18
cp s3://test-jcoleman/test-dir-3/test-file-7 /home/grmrgecko/test/test-dir-3/test-file-7
cp s3://test-jcoleman/test-file-6 /home/grmrgecko/test/test-file-6
cp s3://test-jcoleman/test-dir-3/test-file-8 /home/grmrgecko/test/test-dir-3/test-file-8
cp s3://test-jcoleman/test-file-2 /home/grmrgecko/test/test-file-2
cp s3://test-jcoleman/test-dir-1/test-file-1 /home/grmrgecko/test/test-dir-1/test-file-1
cp s3://test-jcoleman/test-dir-2/test-file-17 /home/grmrgecko/test/test-dir-2/test-file-17
cp s3://test-jcoleman/test-dir-2/test-file-9 /home/grmrgecko/test/test-dir-2/test-file-9
cp s3://test-jcoleman/test-dir-3/test-file-19 /home/grmrgecko/test/test-dir-3/test-file-19
cp s3://test-jcoleman/test-dir-1/test-file-17 /home/grmrgecko/test/test-dir-1/test-file-17
cp s3://test-jcoleman/test-dir-2/test-file-22 /home/grmrgecko/test/test-dir-2/test-file-22
cp s3://test-jcoleman/test-file-4 /home/grmrgecko/test/test-file-4
cp s3://test-jcoleman/test-dir-1/test-file-5 /home/grmrgecko/test/test-dir-1/test-file-5
cp s3://test-jcoleman/test-dir-2/test-file-10 /home/grmrgecko/test/test-dir-2/test-file-10
cp s3://test-jcoleman/test-file-5 /home/grmrgecko/test/test-file-5
cp s3://test-jcoleman/test-dir-3/test-file-13 /home/grmrgecko/test/test-dir-3/test-file-13
cp s3://test-jcoleman/test-dir-2/test-file-14 /home/grmrgecko/test/test-dir-2/test-file-14
cp s3://test-jcoleman/test-dir-1/test-file-12 /home/grmrgecko/test/test-dir-1/test-file-12
cp s3://test-jcoleman/test-dir-2/test-file-18 /home/grmrgecko/test/test-dir-2/test-file-18
cp s3://test-jcoleman/test-dir-3/test-file-11 /home/grmrgecko/test/test-dir-3/test-file-11
cp s3://test-jcoleman/test-dir-1/test-file-8 /home/grmrgecko/test/test-dir-1/test-file-8
cp s3://test-jcoleman/test-dir-2/test-file-5 /home/grmrgecko/test/test-dir-2/test-file-5
cp s3://test-jcoleman/test-dir-3/test-file-17 /home/grmrgecko/test/test-dir-3/test-file-17
cp s3://test-jcoleman/test-dir-2/test-file-2 /home/grmrgecko/test/test-dir-2/test-file-2
cp s3://test-jcoleman/test-dir-1/test-file-2 /home/grmrgecko/test/test-dir-1/test-file-2
cp s3://test-jcoleman/test-dir-3/test-file-21 /home/grmrgecko/test/test-dir-3/test-file-21
cp s3://test-jcoleman/test-dir-3/test-file-4 /home/grmrgecko/test/test-dir-3/test-file-4
cp s3://test-jcoleman/test-dir-1/test-file-4 /home/grmrgecko/test/test-dir-1/test-file-4
cp s3://test-jcoleman/test-file-1 /home/grmrgecko/test/test-file-1
cp s3://test-jcoleman/test-dir-3/test-file-6 /home/grmrgecko/test/test-dir-3/test-file-6
```

Test of max-delete with a data set that removes a few directories:
```
$ ./s5cmd --endpoint-url='https://objects.gec.im' sync --no-follow-symlinks --delete --max-delete=5 's3://test-empty-jcoleman/*' ~/test/
Not deleting due 44 being higher than maximum delete limit
```

Test showing delete works with a higher maximum:

```
$ ./s5cmd --endpoint-url='https://objects.gec.im' sync --no-follow-symlinks --delete --max-delete=50 's3://test-empty-jcoleman/*' ~/test/           
rm /home/grmrgecko/test/test-dir-2/test-file-10
rm /home/grmrgecko/test/test-dir-2/test-file-14
rm /home/grmrgecko/test/test-dir-3/test-file-9
rm /home/grmrgecko/test/test-dir-2/test-file-11
rm /home/grmrgecko/test/test-dir-2/test-file-15
rm /home/grmrgecko/test/test-dir-2/test-file-1
rm /home/grmrgecko/test/test-dir-2/test-file-16
rm /home/grmrgecko/test/test-dir-2/test-file-13
rm /home/grmrgecko/test/test-dir-2/test-file-4
rm /home/grmrgecko/test/test-dir-3/test-file-13
rm /home/grmrgecko/test/test-dir-2/test-file-12
rm /home/grmrgecko/test/test-dir-3/test-file-20
rm /home/grmrgecko/test/test-dir-2/test-file-17
rm /home/grmrgecko/test/test-dir-3/test-file-21
rm /home/grmrgecko/test/test-dir-2/test-file-8
rm /home/grmrgecko/test/test-dir-2/test-file-18
rm /home/grmrgecko/test/test-dir-3/test-file-14
rm /home/grmrgecko/test/test-dir-2/test-file-5
rm /home/grmrgecko/test/test-dir-3/test-file-12
rm /home/grmrgecko/test/test-dir-3/test-file-6
rm /home/grmrgecko/test/test-dir-2/test-file-19
rm /home/grmrgecko/test/test-dir-2/test-file-6
rm /home/grmrgecko/test/test-dir-2/test-file-9
rm /home/grmrgecko/test/test-dir-3/test-file-7
rm /home/grmrgecko/test/test-dir-3/test-file-15
rm /home/grmrgecko/test/test-dir-2/test-file-7
rm /home/grmrgecko/test/test-dir-2/test-file-22
rm /home/grmrgecko/test/test-dir-3/test-file-8
rm /home/grmrgecko/test/test-dir-3/test-file-1
rm /home/grmrgecko/test/test-dir-3/test-file-5
rm /home/grmrgecko/test/test-dir-3/test-file-3
rm /home/grmrgecko/test/test-dir-3/test-file-16
rm /home/grmrgecko/test/test-dir-3/test-file-11
rm /home/grmrgecko/test/test-dir-3/test-file-10
rm /home/grmrgecko/test/test-dir-3/test-file-22
rm /home/grmrgecko/test/test-dir-3/test-file-4
rm /home/grmrgecko/test/test-dir-2/test-file-2
rm /home/grmrgecko/test/test-dir-2/test-file-21
rm /home/grmrgecko/test/test-dir-3/test-file-18
rm /home/grmrgecko/test/test-dir-2/test-file-20
rm /home/grmrgecko/test/test-dir-3/test-file-2
rm /home/grmrgecko/test/test-dir-3/test-file-17
rm /home/grmrgecko/test/test-dir-3/test-file-19
rm /home/grmrgecko/test/test-dir-2/test-file-3
```

Test showing not defining option will default to the negative and delete files:

```
$ ./s5cmd --endpoint-url='https://objects.gec.im' sync --no-follow-symlinks --delete 's3://test-empty-jcoleman/*' ~/test/                  
rm /home/grmrgecko/test/test-dir-2/test-file-10
rm /home/grmrgecko/test/test-dir-2/test-file-14
rm /home/grmrgecko/test/test-dir-2/test-file-11
rm /home/grmrgecko/test/test-dir-2/test-file-1
rm /home/grmrgecko/test/test-dir-3/test-file-9
rm /home/grmrgecko/test/test-dir-2/test-file-12
rm /home/grmrgecko/test/test-dir-3/test-file-2
rm /home/grmrgecko/test/test-dir-3/test-file-5
rm /home/grmrgecko/test/test-dir-3/test-file-11
rm /home/grmrgecko/test/test-dir-2/test-file-13
rm /home/grmrgecko/test/test-dir-3/test-file-6
rm /home/grmrgecko/test/test-dir-3/test-file-10
rm /home/grmrgecko/test/test-dir-3/test-file-12
rm /home/grmrgecko/test/test-dir-3/test-file-8
rm /home/grmrgecko/test/test-dir-3/test-file-7
rm /home/grmrgecko/test/test-dir-2/test-file-15
rm /home/grmrgecko/test/test-dir-3/test-file-13
rm /home/grmrgecko/test/test-dir-3/test-file-4
rm /home/grmrgecko/test/test-dir-3/test-file-22
rm /home/grmrgecko/test/test-dir-3/test-file-3
rm /home/grmrgecko/test/test-dir-2/test-file-16
rm /home/grmrgecko/test/test-dir-3/test-file-17
rm /home/grmrgecko/test/test-dir-3/test-file-18
rm /home/grmrgecko/test/test-dir-3/test-file-15
rm /home/grmrgecko/test/test-dir-3/test-file-14
rm /home/grmrgecko/test/test-dir-2/test-file-17
rm /home/grmrgecko/test/test-dir-3/test-file-19
rm /home/grmrgecko/test/test-dir-3/test-file-21
rm /home/grmrgecko/test/test-dir-2/test-file-3
rm /home/grmrgecko/test/test-dir-3/test-file-1
rm /home/grmrgecko/test/test-dir-2/test-file-8
rm /home/grmrgecko/test/test-dir-2/test-file-2
rm /home/grmrgecko/test/test-dir-2/test-file-9
rm /home/grmrgecko/test/test-dir-3/test-file-20
rm /home/grmrgecko/test/test-dir-2/test-file-20
rm /home/grmrgecko/test/test-dir-2/test-file-18
rm /home/grmrgecko/test/test-dir-2/test-file-19
rm /home/grmrgecko/test/test-dir-2/test-file-21
rm /home/grmrgecko/test/test-dir-2/test-file-22
rm /home/grmrgecko/test/test-dir-2/test-file-6
rm /home/grmrgecko/test/test-dir-2/test-file-7
rm /home/grmrgecko/test/test-dir-3/test-file-16
rm /home/grmrgecko/test/test-dir-2/test-file-5
rm /home/grmrgecko/test/test-dir-2/test-file-4
```