### PR TITLE
command/pipe: update `pipe` file compression example

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You can upload remote objects by piping stdin to `s5cmd`:
 
 Or you can compress the data before uploading:
 
-    tar -cf - file.bin | s5cmd pipe s3://bucket/file.bin.tar
+    gzip -c file | s5cmd pipe s3://bucket/file.gz
 
 #### Delete an S3 object
 

--- a/command/pipe.go
+++ b/command/pipe.go
@@ -34,7 +34,7 @@ Examples:
 	03. Download an object and stream it to a bucket
 		> curl https://github.com/peak/s5cmd/ | s5cmd {{.HelpName}} s3://bucket/s5cmd.html
 	04. Compress an object and stream it to a bucket
-		> tar -cf - file.bin | s5cmd {{.HelpName}} s3://bucket/file.bin.tar
+		> gzip -c file | s5cmd {{.HelpName}} s3://bucket/file.gz
 `
 
 func NewPipeCommandFlags() []cli.Flag {


### PR DESCRIPTION
Closes #704 

Replaced

```bash
tar -cf - file.bin | s5cmd pipe s3://bucket/file.bin.tar
```

with

```bash
gzip -c file | s5cmd pipe s3://bucket/file.gz
```

Why?
- Less flags, less confusing
- To be consistent with the other examples