### PR TITLE
log: implement logging to file

### DIFF
--- a/command/app.go
+++ b/command/app.go
@@ -58,6 +58,11 @@ var app = &cli.App{
 			},
 			Usage: "log level: (trace, debug, info, error)",
 		},
+		&cli.StringFlag{
+			Name:  "log-file",
+			Value: "none",
+			Usage: "sets file for logging",
+		},
 		&cli.BoolFlag{
 			Name:  "install-completion",
 			Usage: "get completion installation instructions for your shell (only available for bash, pwsh, and zsh)",
@@ -96,10 +101,11 @@ var app = &cli.App{
 		workerCount := c.Int("numworkers")
 		printJSON := c.Bool("json")
 		logLevel := c.String("log")
+		logFile := c.String("log-file")
 		isStat := c.Bool("stat")
 		endpointURL := c.String("endpoint-url")
 
-		log.Init(logLevel, printJSON)
+		log.Init(logLevel, printJSON, log.LogFile(logFile))
 		parallel.Init(workerCount)
 
 		if retryCount < 0 {

--- a/command/app.go
+++ b/command/app.go
@@ -60,7 +60,7 @@ var app = &cli.App{
 		},
 		&cli.StringFlag{
 			Name:  "log-file",
-			Value: "none",
+			Value: log.NoLogFile,
 			Usage: "sets file for logging",
 		},
 		&cli.BoolFlag{
@@ -105,8 +105,19 @@ var app = &cli.App{
 		isStat := c.Bool("stat")
 		endpointURL := c.String("endpoint-url")
 
+		// If validation fails, initialize the logger without a log file. Then we log the error
+		err := log.IsValidLogFile(logFile)
+		if err != nil {
+			logFile = log.NoLogFile
+		}
+
 		log.Init(logLevel, printJSON, log.LogFile(logFile))
 		parallel.Init(workerCount)
+
+		if err != nil {
+			printError(commandFromContext(c), c.Command.Name, err)
+			return err
+		}
 
 		if retryCount < 0 {
 			err := fmt.Errorf("retry count cannot be a negative value")

--- a/log/log.go
+++ b/log/log.go
@@ -22,10 +22,10 @@ type LoggerOptions struct {
 	logFile string
 }
 
-// Type for setter functions that specify LoggerOptions parameters
+// LoggerOption is type for setter functions that specify LoggerOptions parameters
 type LoggerOption func(*LoggerOptions)
 
-// Setter for LoggerOptions.logFile parameter
+// LogFile is setter for LoggerOptions.logFile parameter
 func LogFile(logFile string) LoggerOption {
 	return func(args *LoggerOptions) {
 		args.logFile = logFile
@@ -87,7 +87,7 @@ type Logger struct {
 	logFiles *LogFiles
 }
 
-// Вefault value that disables the use of the log file
+// NoLogFile is default value that disables the use of the log file
 const NoLogFile string = ""
 
 // New creates new logger.
@@ -193,14 +193,14 @@ func LevelFromString(s string) LogLevel {
 	}
 }
 
-// Closes stdout and stderr if file pointers are not os.Stdout or os.Stderr
+// Close closes stdout and stderr if file pointers are not os.Stdout or os.Stderr
 func (files *LogFiles) Close() {
 	if files.stdout != os.Stdout {
 		files.stdout.Close()
 	}
 }
 
-// Сhecks the path to the file is correct
+// IsValidLogFile checks the path to the file is correct
 func IsValidLogFile(logFile string) error {
 	if logFile == NoLogFile {
 		return nil
@@ -215,7 +215,7 @@ func IsValidLogFile(logFile string) error {
 	return nil
 }
 
-// Creates and/or opens a file for logging if the path to the file was specified.
+// GetLogFiles creates and/or opens a file for logging if the path to the file was specified.
 // Otherwise uses os.Stdout and os.Stderr for logging
 func GetLogFiles(logFile string) *LogFiles {
 	if logFile == NoLogFile {


### PR DESCRIPTION
Hello. First of all I want to thank you for a great tool.

I often use this program from Python using a `subprocess.run` function. I capture the stdout and stderr streams for error handling. Unfortunately, the progress bar for the command  `s5cmd cp` is also output to the stderr stream, and I would like to capture all the output of the `s5cmd` and output the progress bar to the console at the same time.

This small PR adds the ability to log to a file, which will allow error handling and progress bar output.