### PR TITLE
feat: added Head command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Features
 - Added prefix and wildcard support to `cat` command. ([#716](https://github.com/peak/s5cmd/issues/716))
+- Added `head` command. ([#730](https://github.com/peak/s5cmd/pull/730))
 
 ## v2.2.2 - 13 Sep 2023 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ reasons for its fast speed, refer to [benchmarks](./README.md#Benchmarks) sectio
 storage services and local filesystems.
 
 - List buckets and objects
-- Check if objects and buckets exist
 - Upload, download or delete objects
 - Move, copy or rename objects
 - Set Server Side Encryption using AWS Key Management Service (KMS)
@@ -188,6 +187,14 @@ While executing the commands, `s5cmd` detects the region according to the follow
 5. `us-east-1` as default region.
 
 ### Examples
+
+#### Check if a bucket exists
+
+    s5cmd head s3://bucket/
+
+#### Print a remote object's metadata
+
+    s5cmd head s3://bucket/object.gz
 
 #### Download a single S3 object
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ reasons for its fast speed, refer to [benchmarks](./README.md#Benchmarks) sectio
 storage services and local filesystems.
 
 - List buckets and objects
+- Check if objects and buckets exist
 - Upload, download or delete objects
 - Move, copy or rename objects
 - Set Server Side Encryption using AWS Key Management Service (KMS)

--- a/command/app.go
+++ b/command/app.go
@@ -210,6 +210,7 @@ func Commands() []*cli.Command {
 		NewVersionCommand(),
 		NewBucketVersionCommand(),
 		NewPresignCommand(),
+		NewHeadCommand(),
 	}
 }
 

--- a/command/head.go
+++ b/command/head.go
@@ -263,7 +263,6 @@ func (m HeadObjectMessage) String() string {
 		s += fmt.Sprintf("%15s%s", "Metadata: ", metadataString)
 
 		return s
-
 	}
 
 	return s
@@ -305,7 +304,7 @@ func (m HeadBucketMessage) JSON() string {
 
 func validateHeadCommand(c *cli.Context) error {
 	if c.Args().Len() > 1 {
-		return fmt.Errorf("file or bucket name is required")
+		return fmt.Errorf("object or bucket name is required")
 	}
 
 	srcurl, err := url.New(c.Args().Get(0), url.WithVersion(c.String("version-id")),
@@ -315,14 +314,14 @@ func validateHeadCommand(c *cli.Context) error {
 	}
 
 	if srcurl.IsPrefix() {
-		return fmt.Errorf("target have to be a file or a bucket")
+		return fmt.Errorf("target have to be a object or a bucket")
 	}
 
 	if !srcurl.IsRemote() {
-		return fmt.Errorf("target is not a remote object: target should be remote object or bucket")
+		return fmt.Errorf("target should be remote object or bucket")
 	}
 
-	if srcurl.IsWildcard() && !c.Bool("raw") {
+	if srcurl.IsWildcard() && srcurl.IsRaw() {
 		return fmt.Errorf("remote source %q can not contain glob characters", srcurl)
 	}
 

--- a/command/head.go
+++ b/command/head.go
@@ -108,7 +108,7 @@ func (h Head) Run(ctx context.Context) error {
 		}
 
 		msg := HeadBucketMessage{
-			Key: h.src.String(),
+			Bucket: h.src.String(),
 		}
 
 		log.Info(msg)
@@ -140,15 +140,15 @@ func (h Head) Run(ctx context.Context) error {
 }
 
 type HeadObjectMessage struct {
-	Key                  string            `json:"Key,omitempty"`
-	ContentType          string            `json:"ContentType,omitempty"`
-	ServerSideEncryption string            `json:"ServerSideEncryption,omitempty"`
-	LastModified         *time.Time        `json:"LastModified,omitempty"`
-	ContentLength        int64             `json:"ContentLength,omitempty"`
-	StorageClass         string            `json:"StorageClass,omitempty"`
-	VersionID            string            `json:"VersionID,omitempty"`
-	ETag                 string            `json:"ETag,omitempty"`
-	Metadata             map[string]string `json:"Metadata"`
+	Key                  string            `json:"key,omitempty"`
+	ContentType          string            `json:"content_type,omitempty"`
+	ServerSideEncryption string            `json:"server_side_encryption,omitempty"`
+	LastModified         *time.Time        `json:"last_modified,omitempty"`
+	ContentLength        int64             `json:"size,omitempty"`
+	StorageClass         string            `json:"storage_class,omitempty"`
+	VersionID            string            `json:"version_id,omitempty"`
+	ETag                 string            `json:"etag,omitempty"`
+	Metadata             map[string]string `json:"metadata"`
 }
 
 func (m HeadObjectMessage) String() string {
@@ -160,7 +160,7 @@ func (m HeadObjectMessage) JSON() string {
 }
 
 type HeadBucketMessage struct {
-	Key string `json:"Key"`
+	Bucket string `json:"bucket"`
 }
 
 func (m HeadBucketMessage) String() string {

--- a/command/head.go
+++ b/command/head.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/urfave/cli/v2"
-
+	"github.com/peak/s5cmd/v2/log"
 	"github.com/peak/s5cmd/v2/log/stat"
 	"github.com/peak/s5cmd/v2/storage"
 	"github.com/peak/s5cmd/v2/storage/url"
+	"github.com/peak/s5cmd/v2/strutil"
+	"github.com/urfave/cli/v2"
 )
 
 var headHelpTemplate = `Name:
@@ -35,6 +36,42 @@ func NewHeadCommand() *cli.Command {
 		Usage:    "print remote object metadata",
 
 		CustomHelpTemplate: headHelpTemplate,
+
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "etag",
+				Aliases: []string{"e"},
+				Usage:   "show entity tag (ETag) in the output",
+			},
+			&cli.BoolFlag{
+				Name:    "humanize",
+				Aliases: []string{"H"},
+				Usage:   "human-readable output for object sizes",
+			},
+			&cli.BoolFlag{
+				Name:    "storage-class",
+				Aliases: []string{"s"},
+				Usage:   "display full name of the object class",
+				Value:   true,
+			},
+
+			&cli.BoolFlag{
+				Name:  "all-versions",
+				Usage: "list all versions of object(s)",
+			},
+			&cli.BoolFlag{
+				Name:  "show-fullpath",
+				Usage: "shows only the fullpath names of the object(s)",
+			},
+		},
+
+		Before: func(c *cli.Context) error {
+			err := validateHEADCommand(c)
+			if err != nil {
+				printError(commandFromContext(c), c.Command.Name, err)
+			}
+			return err
+		},
 		Action: func(c *cli.Context) (err error) {
 
 			//print the command name
@@ -62,6 +99,12 @@ func NewHeadCommand() *cli.Command {
 				src:         src,
 				op:          op,
 				fullCommand: fullCommand,
+				//flag
+				showEtag:         c.Bool("etag"),
+				humanize:         c.Bool("humanize"),
+				showStorageClass: c.Bool("storage-class"),
+				showFullPath:     c.Bool("show-fullpath"),
+
 				storageOpts: NewStorageOpts(c),
 			}.Run(c.Context)
 
@@ -75,22 +118,183 @@ type Head struct {
 	src         *url.URL
 	op          string
 	fullCommand string
+
+	showEtag         bool
+	humanize         bool
+	showStorageClass bool
+	showFullPath     bool
+
 	storageOpts storage.Options
 }
 
 func (h Head) Run(ctx context.Context) error {
-	fmt.Println("Context: ", ctx)
+	h.src.SetRelative(h.src)
 	client, err := storage.NewRemoteClient(ctx, h.src, h.storageOpts)
 	if err != nil {
 		printError(h.fullCommand, h.op, err)
 		return err
 	}
-	head_response, err := client.Stat(ctx, h.src)
+
+	if h.src.IsBucket() {
+		bucket, err := client.HeadBucket(ctx, h.src)
+		if err != nil {
+			printError(h.fullCommand, h.op, err)
+			return err
+		}
+
+		msg := HeadBucketMessage{
+			Bucket: bucket,
+		}
+
+		log.Info(msg)
+
+		return nil
+
+	}
+
+	object, metadata, err := client.HeadObject(ctx, h.src)
+
+	//print the metadata all fields
+
+	//fmt.Println("metadata: ", metadata)
+
 	if err != nil {
 		printError(h.fullCommand, h.op, err)
 		return err
 	}
-	fmt.Println("Head response: ", head_response)
+
+	msg := HeadObjectMessage{
+		Object:           object,
+		showEtag:         h.showEtag,
+		showHumanized:    h.humanize,
+		showStorageClass: h.showStorageClass,
+		showFullPath:     h.showFullPath,
+		Metadata:         metadata,
+	}
+
+	log.Info(msg)
+
+	return nil
+}
+
+type HeadObjectMessage struct {
+	Object *storage.Object `json:"object"`
+
+	showEtag         bool
+	showHumanized    bool
+	showStorageClass bool
+	showFullPath     bool
+	Metadata         map[string]string `json:"metadata"`
+}
+
+func (l HeadObjectMessage) String() string {
+	if l.showFullPath {
+		return l.Object.URL.String()
+	}
+	var etag string
+	// date and storage fiels
+	var listFormat = "%19s %2s"
+
+	// align etag
+	if l.showEtag {
+		etag = l.Object.Etag
+		listFormat = listFormat + " %-38s"
+	} else {
+		listFormat = listFormat + " %-1s"
+	}
+
+	// format file size
+	listFormat = listFormat + " %12s "
+	// format key and version ID
+	if l.Object.URL.VersionID != "" {
+		listFormat = listFormat + " %-50s %s"
+	} else {
+		listFormat = listFormat + " %s%s"
+	}
+
+	var s string
+	if l.Object.Type.IsDir() {
+		s = fmt.Sprintf(
+			listFormat,
+			"",
+			"",
+			"",
+			"DIR",
+			l.Object.URL.Relative(),
+			"",
+		)
+		return s
+	}
+
+	stclass := ""
+	if l.showStorageClass {
+		stclass = fmt.Sprintf("%v", l.Object.StorageClass)
+	}
+
+	var path string
+	if l.showFullPath {
+		path = l.Object.URL.String()
+	} else {
+		path = l.Object.URL.Relative()
+	}
+
+	s = fmt.Sprintf(
+		listFormat,
+		l.Object.ModTime.Format(dateFormat),
+		stclass,
+		etag,
+		l.humanize(),
+		path,
+		l.Object.URL.VersionID,
+	)
+
+	return s
+}
+
+func (m HeadObjectMessage) JSON() string {
+	return strutil.JSON(m.Object)
+}
+
+func (l HeadObjectMessage) humanize() string {
+	var size string
+	if l.showHumanized {
+		size = strutil.HumanizeBytes(l.Object.Size)
+	} else {
+		size = fmt.Sprintf("%d", l.Object.Size)
+	}
+	return size
+}
+
+type HeadBucketMessage struct {
+	Bucket *storage.Bucket `json:"bucket"`
+}
+
+func (l HeadBucketMessage) String() string {
+	return l.Bucket.Name
+}
+
+func (m HeadBucketMessage) JSON() string {
+	return strutil.JSON(m.Bucket)
+}
+
+func validateHEADCommand(c *cli.Context) error {
+	if c.Args().Len() > 1 {
+		return fmt.Errorf("expected only 1 argument")
+	}
+
+	srcurl, err := url.New(c.Args().First(),
+		url.WithAllVersions(c.Bool("all-versions")))
+	if err != nil {
+		return err
+	}
+
+	if err := checkVersinoningURLRemote(srcurl); err != nil {
+		return err
+	}
+
+	if err := checkVersioningWithGoogleEndpoint(c); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/command/head.go
+++ b/command/head.go
@@ -26,22 +26,22 @@ Examples:
 		 > s5cmd {{.HelpName}} s3://bucket/prefix/object
 
 	2. Check if a remote bucket exists
-		 > s5cmd {{.HelpName}} s3://bucket 
-	
+		 > s5cmd {{.HelpName}} s3://bucket
+
 	3. Print a remote object's metadata with human-readable sizes
 		 > s5cmd {{.HelpName}} --humanize s3://bucket/prefix/object
-	
+
 	4. Print a remote object's metadata with ETag
 		 > s5cmd {{.HelpName}} --etag s3://bucket/prefix/object
-	
+
 	5. Print a remote object's fullpath
 		 > s5cmd {{.HelpName}} --show-fullpath s3://bucket/prefix/object
-	
+
 	6. Print a remote object's metadata with version ID
 		 > s5cmd {{.HelpName}} --version-id VERSION_ID s3://bucket/prefix/object
-	
+
 	7. Print a remote object's metadata with raw input
-		 > s5cmd {{.HelpName}} --raw s3://bucket/prefix/object
+		 > s5cmd {{.HelpName}} --raw 's3://bucket/prefix/object/with/*'
 
 `
 
@@ -135,6 +135,7 @@ type Head struct {
 }
 
 func (h Head) Run(ctx context.Context) error {
+	// to get the relative path
 	h.src.SetRelative(h.src)
 	client, err := storage.NewRemoteClient(ctx, h.src, h.storageOpts)
 	if err != nil {
@@ -179,13 +180,13 @@ func (h Head) Run(ctx context.Context) error {
 }
 
 type HeadObjectMessage struct {
-	Object *storage.Object `json:"object"`
+	Object *storage.Object
 
 	showEtag         bool
 	showHumanized    bool
 	showStorageClass bool
 	showFullPath     bool
-	Metadata         map[string]string `json:"metadata"`
+	Metadata         map[string]string
 }
 
 func (m HeadObjectMessage) String() string {
@@ -297,7 +298,7 @@ func validateHeadCommand(c *cli.Context) error {
 		return err
 	}
 
-	if srcurl.IsWildcard() {
+	if srcurl.IsWildcard() && !c.Bool("raw") {
 		return fmt.Errorf("remote source %q can not contain glob characters", srcurl)
 	}
 

--- a/command/head.go
+++ b/command/head.go
@@ -94,8 +94,6 @@ type Head struct {
 }
 
 func (h Head) Run(ctx context.Context) error {
-	// to get the relative path
-	h.src.SetRelative(h.src)
 	client, err := storage.NewRemoteClient(ctx, h.src, h.storageOpts)
 	if err != nil {
 		printError(h.fullCommand, h.op, err)

--- a/command/head.go
+++ b/command/head.go
@@ -73,20 +73,10 @@ func NewHeadCommand() *cli.Command {
 			return err
 		},
 		Action: func(c *cli.Context) (err error) {
-
-			//print the command name
-			//fmt.Println(c.Command.FullName())
-
 			defer stat.Collect(c.Command.FullName(), &err)()
 
-			//fmt.Println("head command")
-
 			op := c.Command.Name
-			//fmt.Println("op: ", op)
 			fullCommand := commandFromContext(c)
-
-			//print the command name
-			//fmt.Println("fullCommand: ", fullCommand)
 
 			src, err := url.New(c.Args().Get(0), url.WithVersion(c.String("version-id")),
 				url.WithRaw(c.Bool("raw")))
@@ -99,7 +89,7 @@ func NewHeadCommand() *cli.Command {
 				src:         src,
 				op:          op,
 				fullCommand: fullCommand,
-				//flag
+				//flags
 				showEtag:         c.Bool("etag"),
 				humanize:         c.Bool("humanize"),
 				showStorageClass: c.Bool("storage-class"),
@@ -107,7 +97,6 @@ func NewHeadCommand() *cli.Command {
 
 				storageOpts: NewStorageOpts(c),
 			}.Run(c.Context)
-
 		},
 	}
 	cmd.BashComplete = getBashCompleteFn(cmd, true, false)
@@ -149,14 +138,9 @@ func (h Head) Run(ctx context.Context) error {
 		log.Info(msg)
 
 		return nil
-
 	}
 
 	object, metadata, err := client.HeadObject(ctx, h.src)
-
-	//print the metadata all fields
-
-	//fmt.Println("metadata: ", metadata)
 
 	if err != nil {
 		printError(h.fullCommand, h.op, err)
@@ -192,7 +176,7 @@ func (m HeadObjectMessage) String() string {
 		return m.Object.URL.String()
 	}
 	var etag string
-	// date and storage fiels
+	// date and storage fields
 	var listFormat = "%19s %2s"
 
 	// align etag

--- a/command/head.go
+++ b/command/head.go
@@ -1,0 +1,96 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/peak/s5cmd/v2/log/stat"
+	"github.com/peak/s5cmd/v2/storage"
+	"github.com/peak/s5cmd/v2/storage/url"
+)
+
+var headHelpTemplate = `Name:
+	{{.HelpName}} - {{.Usage}}
+
+Usage:
+	{{.HelpName}} [options] source
+
+Options:
+	{{range .VisibleFlags}}{{.}}
+	{{end}}
+Examples:
+	1. Print a remote object's metadata
+		 > s5cmd {{.HelpName}} s3://bucket/prefix/object
+
+	2. Print specific version of a remote object's metadata
+		 > s5cmd {{.HelpName}} --version-id VERSION_ID s3://bucket/prefix/object
+`
+
+func NewHeadCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name:     "head",
+		HelpName: "head",
+		Usage:    "print remote object metadata",
+
+		CustomHelpTemplate: headHelpTemplate,
+		Action: func(c *cli.Context) (err error) {
+
+			//print the command name
+			//fmt.Println(c.Command.FullName())
+
+			defer stat.Collect(c.Command.FullName(), &err)()
+
+			//fmt.Println("head command")
+
+			op := c.Command.Name
+			//fmt.Println("op: ", op)
+			fullCommand := commandFromContext(c)
+
+			//print the command name
+			//fmt.Println("fullCommand: ", fullCommand)
+
+			src, err := url.New(c.Args().Get(0), url.WithVersion(c.String("version-id")),
+				url.WithRaw(c.Bool("raw")))
+			if err != nil {
+				printError(fullCommand, op, err)
+				return err
+			}
+
+			return Head{
+				src:         src,
+				op:          op,
+				fullCommand: fullCommand,
+				storageOpts: NewStorageOpts(c),
+			}.Run(c.Context)
+
+		},
+	}
+	cmd.BashComplete = getBashCompleteFn(cmd, true, false)
+	return cmd
+}
+
+type Head struct {
+	src         *url.URL
+	op          string
+	fullCommand string
+	storageOpts storage.Options
+}
+
+func (h Head) Run(ctx context.Context) error {
+	fmt.Println("Context: ", ctx)
+	client, err := storage.NewRemoteClient(ctx, h.src, h.storageOpts)
+	if err != nil {
+		printError(h.fullCommand, h.op, err)
+		return err
+	}
+	head_response, err := client.Stat(ctx, h.src)
+	if err != nil {
+		printError(h.fullCommand, h.op, err)
+		return err
+	}
+	fmt.Println("Head response: ", head_response)
+
+	return nil
+}

--- a/command/head.go
+++ b/command/head.go
@@ -187,17 +187,17 @@ type HeadObjectMessage struct {
 	Metadata         map[string]string `json:"metadata"`
 }
 
-func (l HeadObjectMessage) String() string {
-	if l.showFullPath {
-		return l.Object.URL.String()
+func (m HeadObjectMessage) String() string {
+	if m.showFullPath {
+		return m.Object.URL.String()
 	}
 	var etag string
 	// date and storage fiels
 	var listFormat = "%19s %2s"
 
 	// align etag
-	if l.showEtag {
-		etag = l.Object.Etag
+	if m.showEtag {
+		etag = m.Object.Etag
 		listFormat = listFormat + " %-38s"
 	} else {
 		listFormat = listFormat + " %-1s"
@@ -206,46 +206,46 @@ func (l HeadObjectMessage) String() string {
 	// format file size
 	listFormat = listFormat + " %12s "
 	// format key and version ID
-	if l.Object.URL.VersionID != "" {
+	if m.Object.URL.VersionID != "" {
 		listFormat = listFormat + " %-50s %s"
 	} else {
 		listFormat = listFormat + " %s%s"
 	}
 
 	var s string
-	if l.Object.Type.IsDir() {
+	if m.Object.Type.IsDir() {
 		s = fmt.Sprintf(
 			listFormat,
 			"",
 			"",
 			"",
 			"DIR",
-			l.Object.URL.Relative(),
+			m.Object.URL.Relative(),
 			"",
 		)
 		return s
 	}
 
 	stclass := ""
-	if l.showStorageClass {
-		stclass = fmt.Sprintf("%v", l.Object.StorageClass)
+	if m.showStorageClass {
+		stclass = fmt.Sprintf("%v", m.Object.StorageClass)
 	}
 
 	var path string
-	if l.showFullPath {
-		path = l.Object.URL.String()
+	if m.showFullPath {
+		path = m.Object.URL.String()
 	} else {
-		path = l.Object.URL.Relative()
+		path = m.Object.URL.Relative()
 	}
 
 	s = fmt.Sprintf(
 		listFormat,
-		l.Object.ModTime.Format(dateFormat),
+		m.Object.ModTime.Format(dateFormat),
 		stclass,
 		etag,
-		l.humanize(),
+		m.humanize(),
 		path,
-		l.Object.URL.VersionID,
+		m.Object.URL.VersionID,
 	)
 
 	return s
@@ -255,12 +255,12 @@ func (m HeadObjectMessage) JSON() string {
 	return strutil.JSON(m.Object)
 }
 
-func (l HeadObjectMessage) humanize() string {
+func (m HeadObjectMessage) humanize() string {
 	var size string
-	if l.showHumanized {
-		size = strutil.HumanizeBytes(l.Object.Size)
+	if m.showHumanized {
+		size = strutil.HumanizeBytes(m.Object.Size)
 	} else {
-		size = fmt.Sprintf("%d", l.Object.Size)
+		size = fmt.Sprintf("%d", m.Object.Size)
 	}
 	return size
 }
@@ -269,8 +269,8 @@ type HeadBucketMessage struct {
 	Bucket *storage.Bucket `json:"bucket"`
 }
 
-func (l HeadBucketMessage) String() string {
-	return l.Bucket.Name
+func (m HeadBucketMessage) String() string {
+	return m.Bucket.Name
 }
 
 func (m HeadBucketMessage) JSON() string {

--- a/command/ls.go
+++ b/command/ls.go
@@ -254,7 +254,7 @@ func (l ListMessage) String() string {
 		return l.Object.URL.String()
 	}
 	var etag string
-	// date and storage fiels
+	// date and storage fields
 	var listFormat = "%19s %2s"
 
 	// align etag

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
-//head (without anything -> error)
+// head (without anything -> error)
 
 func TestHead(t *testing.T) {
 	t.Parallel()
@@ -20,8 +20,6 @@ func TestHead(t *testing.T) {
 
 	result.Assert(t, icmd.Expected{ExitCode: 1})
 }
-
-// ------------------ Bucket Tests ------------------
 
 // head bucket
 
@@ -64,8 +62,6 @@ func TestHeadBucketJSON(t *testing.T) {
 
 	cmd := s5cmd("--json", "head", fmt.Sprintf("s3://%v", bucket))
 	result := icmd.RunCmd(cmd)
-
-	//{"created_at":"2021/09/01 00:00:00","name":"bucket"}
 
 	result.Assert(t, icmd.Expected{ExitCode: 0, Out: fmt.Sprintf(`{"created_at":"%v","name":"%v"}`, "0001-01-01T00:00:00Z", bucket)})
 }
@@ -130,8 +126,6 @@ func TestHeadBucketStorageClass(t *testing.T) {
 	result.Assert(t, icmd.Expected{ExitCode: 0, Out: bucket})
 }
 
-// ------------------ Object Tests ------------------
-
 // head object
 
 func TestHeadObjectOutput(t *testing.T) {
@@ -151,7 +145,6 @@ func TestHeadObjectOutput(t *testing.T) {
 	sizePattern := `\d+`
 	s3urlPattern := `myfile.txt`
 
-	// Beklenen çıktıyı regex pattern'ları ile oluşturuyoruz
 	expectedOutput := fmt.Sprintf(
 		`%s\s+%s\s+%s\s+%s`,
 		datePattern,
@@ -160,7 +153,6 @@ func TestHeadObjectOutput(t *testing.T) {
 		s3urlPattern,
 	)
 
-	// Regex ile eşleştirme yaparak sonucu kontrol ediyoruz
 	match, err := regexp.MatchString(expectedOutput, result.Combined())
 	if err != nil {
 		t.Fatalf("regex match failed: %v", err)
@@ -170,7 +162,6 @@ func TestHeadObjectOutput(t *testing.T) {
 		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
 	}
 
-	// Çıkış kodunu kontrol ediyoruz
 	result.Assert(t, icmd.Expected{ExitCode: 0})
 }
 
@@ -297,8 +288,6 @@ func TestHeadObjectEtag(t *testing.T) {
 
 	cmd := s5cmd("head", "--etag", fmt.Sprintf("s3://%v/file.txt", bucket))
 	result := icmd.RunCmd(cmd)
-
-	//  2024/07/03 13:13:15 STANDART 9a0364b9e99bb480dd25e1f0284c8555                  7  file.txt
 
 	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
 	storageClassPattern := `(?:STANDART|)`

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -157,16 +157,19 @@ func TestHeadObjectJSON(t *testing.T) {
 func TestHeadObjectJSONNonExistent(t *testing.T) {
 	t.Parallel()
 
-	_, s5cmd := setup(t)
+	s3client, s5cmd := setup(t)
 
-	cmd := s5cmd("--json", "head", "s3://non-existent-bucket/non-existent-file.txt")
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("--json", "head", fmt.Sprintf("s3://%v/non-existent-file.txt", bucket))
 	result := icmd.RunCmd(cmd)
 
 	result.Assert(t, icmd.Expected{ExitCode: 1})
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{
 		0: contains(`non-existent-file.txt not found`),
-	})
+	}, jsonCheck(true), strictLineCheck(false))
 }
 
 // head --raw objectWithGlobChar

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 // head (without anything -> error)
-
 func TestHead(t *testing.T) {
 	t.Parallel()
 
@@ -22,7 +21,6 @@ func TestHead(t *testing.T) {
 }
 
 // head bucket
-
 func TestHeadBucket(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +40,6 @@ func TestHeadBucket(t *testing.T) {
 }
 
 // head bucket (non-existent)
-
 func TestHeadBucketNonExistent(t *testing.T) {
 	t.Parallel()
 
@@ -55,7 +52,6 @@ func TestHeadBucketNonExistent(t *testing.T) {
 }
 
 // --json head bucket
-
 func TestHeadBucketJSON(t *testing.T) {
 	t.Parallel()
 
@@ -75,7 +71,6 @@ func TestHeadBucketJSON(t *testing.T) {
 }
 
 // --json head bucket (non-existent)
-
 func TestHeadBucketJSONNonExistent(t *testing.T) {
 	t.Parallel()
 
@@ -88,7 +83,6 @@ func TestHeadBucketJSONNonExistent(t *testing.T) {
 }
 
 // head bucket --humanize
-
 func TestHeadBucketHumanize(t *testing.T) {
 	t.Parallel()
 
@@ -127,7 +121,6 @@ func TestHeadBucketEtag(t *testing.T) {
 }
 
 // head bucket --storage-class
-
 func TestHeadBucketStorageClass(t *testing.T) {
 	t.Parallel()
 
@@ -147,7 +140,6 @@ func TestHeadBucketStorageClass(t *testing.T) {
 }
 
 // head object
-
 func TestHeadObject(t *testing.T) {
 	t.Parallel()
 
@@ -162,16 +154,7 @@ func TestHeadObject(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	storageClassPattern := `(?:STANDARD|)`
-	sizePattern := `\d+`
-	s3urlPattern := `myfile.txt`
-
-	expectedOutput := fmt.Sprintf(
-		`%s\s+%s\s+%s`,
-		storageClassPattern,
-		sizePattern,
-		s3urlPattern,
-	)
+	expectedOutput := `(?:STANDARD|)\s+\d+\s+myfile.txt`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -179,7 +162,6 @@ func TestHeadObject(t *testing.T) {
 }
 
 // head object (non-existent)
-
 func TestHeadObjectNonExistent(t *testing.T) {
 	t.Parallel()
 
@@ -195,7 +177,6 @@ func TestHeadObjectNonExistent(t *testing.T) {
 }
 
 // --json head object
-
 func TestHeadObjectJSON(t *testing.T) {
 	t.Parallel()
 
@@ -232,7 +213,6 @@ func TestHeadObjectJSON(t *testing.T) {
 }
 
 // --json head object (non-existent)
-
 func TestHeadObjectJSONNonExistent(t *testing.T) {
 	t.Parallel()
 
@@ -245,7 +225,6 @@ func TestHeadObjectJSONNonExistent(t *testing.T) {
 }
 
 // head object --humanize
-
 func TestHeadObjectHumanize(t *testing.T) {
 	t.Parallel()
 
@@ -264,18 +243,7 @@ func TestHeadObjectHumanize(t *testing.T) {
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
-	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDARD|)`
-	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
-	s3urlPattern := `file.txt`
-
-	expectedOutput := fmt.Sprintf(
-		`%s\s+%s\s+%s\s+%s`,
-		datePattern,
-		storageClassPattern,
-		sizePattern,
-		s3urlPattern,
-	)
+	expectedOutput := `(?:STANDARD|)\s+(?:\d+(\.\d+)?[KMGTP]?B?)\s+file.txt`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -283,7 +251,6 @@ func TestHeadObjectHumanize(t *testing.T) {
 }
 
 // head object --etag
-
 func TestHeadObjectEtag(t *testing.T) {
 	t.Parallel()
 
@@ -297,28 +264,14 @@ func TestHeadObjectEtag(t *testing.T) {
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
-	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDARD|)`
-	sizePattern := `\d+`
-	s3urlPattern := `file.txt`
-	etagPattern := `[a-f0-9]+`
-
-	expectedOutput := fmt.Sprintf(
-		`%s\s+%s\s+%s\s+%s\s+%s`,
-		datePattern,
-		storageClassPattern,
-		etagPattern,
-		sizePattern,
-		s3urlPattern,
-	)
+	expectedOutput := `(?:STANDARD|)\s+[a-f0-9]+\s+(?:\d+(\.\d+)?[KMGTP]?B?)\s+file.txt`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
-	}, alignment(true))
+	}, trimMatch(dateRe), alignment(true))
 }
 
 // head object --show-fullpath
-
 func TestHeadObjectShowFullpath(t *testing.T) {
 	t.Parallel()
 
@@ -354,7 +307,6 @@ func TestHeadObjectShowFullpathNonExistent(t *testing.T) {
 }
 
 // head object --humanize --etag
-
 func TestHeadObjectHumanizeEtag(t *testing.T) {
 	t.Parallel()
 
@@ -374,29 +326,15 @@ func TestHeadObjectHumanizeEtag(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDARD|)`
-	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
-	s3urlPattern := `file.txt`
-	etagPattern := `[a-f0-9]+`
-
-	expectedOutput := fmt.Sprintf(
-		`%s\s+%s\s+%s\s+%s\s+%s`,
-		datePattern,
-		storageClassPattern,
-		etagPattern,
-		sizePattern,
-		s3urlPattern,
-	)
+	expectedOutput := `(?:STANDARD|)\s+[a-f0-9]+\s+(?:\d+(\.\d+)?[KMGTP]?B?)\s+file.txt`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
-	}, alignment(true))
+	}, trimMatch(dateRe), alignment(true))
 }
 
 // head --raw objectWithGlobChar
 // head --raw s3://bucket/file*.txt
-
 func TestHeadObjectRaw(t *testing.T) {
 	t.Parallel()
 
@@ -411,22 +349,11 @@ func TestHeadObjectRaw(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDARD|)`
-	sizePattern := `\d+`
-	s3urlPattern := `file\*.txt`
-
-	expectedOutput := fmt.Sprintf(
-		`%s\s+%s\s+%s\s+%s`,
-		datePattern,
-		storageClassPattern,
-		sizePattern,
-		s3urlPattern,
-	)
+	expectedOutput := `(?:STANDARD|)\s+\d+\s+file\*.txt`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
-	}, alignment(true))
+	}, trimMatch(dateRe), alignment(true))
 }
 
 // head object s3://bucket/file*.txt
@@ -443,7 +370,6 @@ func TestHeadObjectWildcardWithoutRawFlag(t *testing.T) {
 }
 
 // head --json object s3://bucket/file.txt (metadata)
-
 func TestHeadObjectJSONMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -537,22 +463,13 @@ func TestHeadObjectWithVersionID(t *testing.T) {
 		result = icmd.RunCmd(cmd)
 		result.Assert(t, icmd.Success)
 
-		datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-		storageClassPattern := `(?:STANDARD|)`
-		sizePattern := len(contents[i])
-		s3urlPattern := filename
-
 		expectedOutput := fmt.Sprintf(
-			`%s\s+%s\s+%d\s+%s`,
-			datePattern,
-			storageClassPattern,
-			sizePattern,
-			s3urlPattern,
+			`(?:STANDARD|)\s+%d+\s+testfile.txt`,
+			len(contents[i]),
 		)
 
 		assertLines(t, result.Stdout(), map[int]compareFunc{
 			0: match(expectedOutput),
-		}, alignment(true))
-
+		}, trimMatch(dateRe), alignment(true))
 	}
 }

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -1,0 +1,407 @@
+package e2e
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+//head (without anything -> error)
+
+func TestHead(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	cmd := s5cmd("head")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// ------------------ Bucket Tests ------------------
+
+// head bucket
+
+func TestHeadBucket(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("head", fmt.Sprintf("s3://%v", bucket))
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 0, Out: bucket})
+}
+
+// head bucket (non-existent)
+
+func TestHeadBucketNonExistent(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	cmd := s5cmd("head", "s3://non-existent-bucket")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// --json head bucket
+
+func TestHeadBucketJSON(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("--json", "head", fmt.Sprintf("s3://%v", bucket))
+	result := icmd.RunCmd(cmd)
+
+	//{"created_at":"2021/09/01 00:00:00","name":"bucket"}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0, Out: fmt.Sprintf(`{"created_at":"%v","name":"%v"}`, "0001-01-01T00:00:00Z", bucket)})
+}
+
+// --json head bucket (non-existent)
+
+func TestHeadBucketJSONNonExistent(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	cmd := s5cmd("--json", "head", "s3://non-existent-bucket")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// head bucket --humanize
+
+func TestHeadBucketHumanize(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("head", "--humanize", fmt.Sprintf("s3://%v", bucket))
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 0, Out: bucket})
+}
+
+// head bucket --etag
+func TestHeadBucketEtag(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("head", "--etag", fmt.Sprintf("s3://%v", bucket))
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 0, Out: bucket})
+}
+
+// head bucket --storage-class
+
+func TestHeadBucketStorageClass(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("head", "--storage-class", fmt.Sprintf("s3://%v", bucket))
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 0, Out: bucket})
+}
+
+// ------------------ Object Tests ------------------
+
+// head object
+
+func TestHeadObjectOutput(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, "myfile.txt", "content")
+
+	cmd := s5cmd("head", fmt.Sprintf("s3://%v/myfile.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
+	storageClassPattern := `(?:STANDART|)`
+	sizePattern := `\d+`
+	s3urlPattern := `myfile.txt`
+
+	// Beklenen çıktıyı regex pattern'ları ile oluşturuyoruz
+	expectedOutput := fmt.Sprintf(
+		`%s\s+%s\s+%s\s+%s`,
+		datePattern,
+		storageClassPattern,
+		sizePattern,
+		s3urlPattern,
+	)
+
+	// Regex ile eşleştirme yaparak sonucu kontrol ediyoruz
+	match, err := regexp.MatchString(expectedOutput, result.Combined())
+	if err != nil {
+		t.Fatalf("regex match failed: %v", err)
+	}
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	// Çıkış kodunu kontrol ediyoruz
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+}
+
+// head object (non-existent)
+
+func TestHeadObjectNonExistent(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	cmd := s5cmd("head", fmt.Sprintf("s3://%v/non-existent-file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// --json head object
+
+func TestHeadObjectJSON(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, "file.txt", "content")
+
+	cmd := s5cmd("--json", "head", fmt.Sprintf("s3://%v/file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	etagPattern := `\"[^\"]+\"`
+	lastModifiedPattern := `\"[^\"]+\"`
+	typePattern := `\"[^\"]+\"`
+	sizePattern := `\d+`
+	storageClassPattern := `\"[^\"]+\"`
+
+	expectedOutput := fmt.Sprintf(
+		`{"key":"s3://%v/file.txt","etag":%s,"last_modified":%s,"type":%s,"size":%s,"storage_class":%s}`,
+		bucket,
+		etagPattern,
+		lastModifiedPattern,
+		typePattern,
+		sizePattern,
+		storageClassPattern,
+	)
+
+	match, _ := regexp.MatchString(expectedOutput, result.Combined())
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+}
+
+// --json head object (non-existent)
+
+func TestHeadObjectJSONNonExistent(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	cmd := s5cmd("--json", "head", "s3://non-existent-bucket/non-existent-file.txt")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// head object --humanize
+
+func TestHeadObjectHumanize(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	largeFileContent := make([]byte, 1024*1024*50) // 50MB
+	for i := 0; i < len(largeFileContent); i++ {
+		largeFileContent[i] = 'a'
+	}
+	putFile(t, s3client, bucket, "file.txt", string(largeFileContent))
+
+	cmd := s5cmd("head", "--humanize", fmt.Sprintf("s3://%v/file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
+	storageClassPattern := `(?:STANDART|)`
+	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
+	s3urlPattern := `file.txt`
+
+	expectedOutput := fmt.Sprintf(
+		`%s\s+%s\s+%s\s+%s`,
+		datePattern,
+		storageClassPattern,
+		sizePattern,
+		s3urlPattern,
+	)
+
+	match, _ := regexp.MatchString(expectedOutput, result.Combined())
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+
+}
+
+// head object --etag
+
+func TestHeadObjectEtag(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, "file.txt", "content")
+
+	cmd := s5cmd("head", "--etag", fmt.Sprintf("s3://%v/file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	//  2024/07/03 13:13:15 STANDART 9a0364b9e99bb480dd25e1f0284c8555                  7  file.txt
+
+	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
+	storageClassPattern := `(?:STANDART|)`
+	sizePattern := `\d+`
+	s3urlPattern := `file.txt`
+	etagPattern := `[a-f0-9]+`
+
+	expectedOutput := fmt.Sprintf(
+		`%s\s+%s\s+%s\s+%s\s+%s`,
+		datePattern,
+		storageClassPattern,
+		etagPattern,
+		sizePattern,
+		s3urlPattern,
+	)
+
+	match, _ := regexp.MatchString(expectedOutput, result.Combined())
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+}
+
+// head object --show-fullpath
+
+func TestHeadObjectShowFullpath(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	putFile(t, s3client, bucket, "file.txt", "content")
+
+	cmd := s5cmd("head", "--show-fullpath", fmt.Sprintf("s3://%v/file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	s3urlPattern := fmt.Sprintf(`s3://%s/file.txt`, bucket)
+
+	expectedOutput := s3urlPattern
+
+	match, _ := regexp.MatchString(expectedOutput, result.Combined())
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+}
+
+func TestHeadObjectShowFullpathNonExistent(t *testing.T) {
+	t.Parallel()
+
+	_, s5cmd := setup(t)
+
+	cmd := s5cmd("head", "--show-fullpath", "s3://non-existent-bucket/non-existent-file.txt")
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Expected{ExitCode: 1})
+}
+
+// head object --humanize --etag
+
+func TestHeadObjectHumanizeEtag(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	largeFileContent := make([]byte, 1024*1024*50) // 50MB
+	for i := 0; i < len(largeFileContent); i++ {
+		largeFileContent[i] = 'a'
+	}
+	putFile(t, s3client, bucket, "file.txt", string(largeFileContent))
+
+	cmd := s5cmd("head", "--humanize", "--etag", fmt.Sprintf("s3://%v/file.txt", bucket))
+	result := icmd.RunCmd(cmd)
+
+	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
+	storageClassPattern := `(?:STANDART|)`
+	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
+	s3urlPattern := `file.txt`
+	etagPattern := `[a-f0-9]+`
+
+	expectedOutput := fmt.Sprintf(
+		`%s\s+%s\s+%s\s+%s\s+%s`,
+		datePattern,
+		storageClassPattern,
+		etagPattern,
+		sizePattern,
+		s3urlPattern,
+	)
+
+	match, _ := regexp.MatchString(expectedOutput, result.Combined())
+
+	if !match {
+		t.Errorf("expected output to match:\n%s\nbut got:\n%s", expectedOutput, result.Combined())
+	}
+
+	result.Assert(t, icmd.Expected{ExitCode: 0})
+}

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -513,7 +513,7 @@ func TestHeadObjectWithMetadata(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := `(?:STANDARD|)\s+\d+\s+file.txt+\s+Metadata: key1=value1,key2=value2`
+	expectedOutput := `(?:STANDARD|)\s+\d+\s+file.txt\s+Metadata: (?:key1=value1,key2=value2|key2=value2,key1=value1)`
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -39,7 +39,7 @@ func TestHeadBucket(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
-		0: suffix(`{"Key":"s3://%v"}`, bucket),
+		0: suffix(`{"bucket":"s3://%v"}`, bucket),
 	}, jsonCheck(true), strictLineCheck(false))
 }
 
@@ -74,7 +74,7 @@ func TestHeadBucketJSON(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
-		0: suffix(`{"Key":"s3://%v"}`, bucket),
+		0: suffix(`{"bucket":"s3://%v"}`, bucket),
 	}, jsonCheck(true), strictLineCheck(false))
 }
 
@@ -106,7 +106,7 @@ func TestHeadObject(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/myfile.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":\d+,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":\{\}}`, bucket)
+	expectedOutput := fmt.Sprintf(`{"key":"s3://%v/myfile.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":\d+,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":\{\}}`, bucket)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -146,7 +146,7 @@ func TestHeadObjectJSON(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/file.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":\d+,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":\{\}}`, bucket)
+	expectedOutput := fmt.Sprintf(`{"key":"s3://%v/file.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":\d+,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":\{\}}`, bucket)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -188,7 +188,7 @@ func TestHeadObjectRaw(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/file\*.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":\d+,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":\{\}}`, bucket)
+	expectedOutput := fmt.Sprintf(`{"key":"s3://%v/file\*.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":\d+,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":\{\}}`, bucket)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -266,7 +266,7 @@ func TestHeadObjectWithVersionID(t *testing.T) {
 		result = icmd.RunCmd(cmd)
 		result.Assert(t, icmd.Success)
 
-		expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/testfile.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":%d,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":\{\}}`, bucket, len(contents[i]))
+		expectedOutput := fmt.Sprintf(`{"key":"s3://%v/testfile.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":%d,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":\{\}}`, bucket, len(contents[i]))
 
 		assertLines(t, result.Stdout(), map[int]compareFunc{
 			0: match(expectedOutput),
@@ -296,7 +296,7 @@ func TestHeadObjectWithMetadata(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/file.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":\d+,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":{(?:"key1":"value1","key2":"value2"|"key2":"value2","key1":"value1")}}`, bucket)
+	expectedOutput := fmt.Sprintf(`{"key":"s3://%v/file.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":\d+,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":{(?:"key1":"value1","key2":"value2"|"key2":"value2","key1":"value1")}}`, bucket)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),
@@ -324,7 +324,7 @@ func TestHeadObjectJSONMetadata(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	expectedOutput := fmt.Sprintf(`{"Key":"s3://%v/file.txt","LastModified":"[0-9-]+T[0-9:.]+Z","ContentLength":\d+,"StorageClass":"STANDARD","ETag":"[a-f0-9]+","Metadata":{"key1":"value1"}}`, bucket)
+	expectedOutput := fmt.Sprintf(`{"key":"s3://%v/file.txt","last_modified":"[0-9-]+T[0-9:.]+Z","size":\d+,"storage_class":"STANDARD","etag":"[a-f0-9]+","metadata":{"key1":"value1"}}`, bucket)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: match(expectedOutput),

--- a/e2e/head_test.go
+++ b/e2e/head_test.go
@@ -162,7 +162,7 @@ func TestHeadObject(t *testing.T) {
 
 	result.Assert(t, icmd.Success)
 
-	storageClassPattern := `(?:STANDART|)`
+	storageClassPattern := `(?:STANDARD|)`
 	sizePattern := `\d+`
 	s3urlPattern := `myfile.txt`
 
@@ -265,7 +265,7 @@ func TestHeadObjectHumanize(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDART|)`
+	storageClassPattern := `(?:STANDARD|)`
 	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
 	s3urlPattern := `file.txt`
 
@@ -298,7 +298,7 @@ func TestHeadObjectEtag(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDART|)`
+	storageClassPattern := `(?:STANDARD|)`
 	sizePattern := `\d+`
 	s3urlPattern := `file.txt`
 	etagPattern := `[a-f0-9]+`
@@ -375,7 +375,7 @@ func TestHeadObjectHumanizeEtag(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDART|)`
+	storageClassPattern := `(?:STANDARD|)`
 	sizePattern := `(?:\d+(\.\d+)?[KMGTP]?B?)`
 	s3urlPattern := `file.txt`
 	etagPattern := `[a-f0-9]+`
@@ -412,7 +412,7 @@ func TestHeadObjectRaw(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-	storageClassPattern := `(?:STANDART|)`
+	storageClassPattern := `(?:STANDARD|)`
 	sizePattern := `\d+`
 	s3urlPattern := `file\*.txt`
 
@@ -538,7 +538,7 @@ func TestHeadObjectWithVersionID(t *testing.T) {
 		result.Assert(t, icmd.Success)
 
 		datePattern := `\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}`
-		storageClassPattern := `(?:STANDART|)`
+		storageClassPattern := `(?:STANDARD|)`
 		sizePattern := len(contents[i])
 		s3urlPattern := filename
 

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -244,7 +244,7 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	assertLines(t, result.Stderr(), map[int]compareFunc{})
 }
 
-/*func TestRunSpecialCharactersInPrefix(t *testing.T) {
+func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	t.Parallel()
 
 	bucket := s3BucketFromTestName(t)
@@ -272,7 +272,7 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	}, sortInput(true))
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{})
-}*/
+}
 
 func TestRunDryRun(t *testing.T) {
 	t.Parallel()

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -244,7 +244,7 @@ func TestRunWildcardCountGreaterEqualThanWorkerCount(t *testing.T) {
 	assertLines(t, result.Stderr(), map[int]compareFunc{})
 }
 
-func TestRunSpecialCharactersInPrefix(t *testing.T) {
+/*func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	t.Parallel()
 
 	bucket := s3BucketFromTestName(t)
@@ -272,7 +272,7 @@ func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	}, sortInput(true))
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{})
-}
+}*/
 
 func TestRunDryRun(t *testing.T) {
 	t.Parallel()

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1161,10 +1161,7 @@ func (s *S3) HeadBucket(ctx context.Context, url *url.URL) error {
 	_, err := s.api.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(url.Bucket),
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]string, error) {
@@ -1188,7 +1185,6 @@ func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]
 
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#AmazonS3-HeadObject-response-header-StorageClass
 	// If the object's storage class is STANDARD, this header is not returned in the response.
-
 	storageClassStr := "STANDARD"
 	if output.StorageClass != nil {
 		storageClassStr = aws.StringValue(output.StorageClass)

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1165,7 +1165,6 @@ func (s *S3) GetBucketVersioning(ctx context.Context, bucket string) (string, er
 }
 
 func (s *S3) HeadBucket(ctx context.Context, url *url.URL) (*Bucket, error) {
-
 	output, err := s.api.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(url.Bucket),
 	})
@@ -1185,7 +1184,6 @@ func (s *S3) HeadBucket(ctx context.Context, url *url.URL) (*Bucket, error) {
 }
 
 func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]string, error) {
-
 	input := &s3.HeadObjectInput{
 		Bucket:       aws.String(url.Bucket),
 		Key:          aws.String(url.Path),

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1189,7 +1189,7 @@ func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#AmazonS3-HeadObject-response-header-StorageClass
 	// If the object's storage class is STANDARD, this header is not returned in the response.
 
-	storageClassStr := "STANDART"
+	storageClassStr := "STANDARD"
 	if output.StorageClass != nil {
 		storageClassStr = aws.StringValue(output.StorageClass)
 	}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1164,7 +1164,7 @@ func (s *S3) HeadBucket(ctx context.Context, url *url.URL) error {
 	return err
 }
 
-func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]string, error) {
+func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, *Metadata, error) {
 	input := &s3.HeadObjectInput{
 		Bucket:       aws.String(url.Bucket),
 		Key:          aws.String(url.Path),
@@ -1198,7 +1198,11 @@ func (s *S3) HeadObject(ctx context.Context, url *url.URL) (*Object, map[string]
 		StorageClass: StorageClass(storageClassStr),
 	}
 
-	metadata := aws.StringValueMap(output.Metadata)
+	metadata := &Metadata{
+		ContentType:      aws.StringValue(output.ContentType),
+		EncryptionMethod: aws.StringValue(output.ServerSideEncryption),
+		UserDefined:      aws.StringValueMap(output.Metadata),
+	}
 
 	return obj, metadata, nil
 }

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -81,7 +81,6 @@ func TestNewSessionPathStyle(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			opts := Options{Endpoint: tc.endpoint.String()}
 			sess, err := globalSessionCache.newSession(context.Background(), opts)
 			if err != nil {
@@ -180,7 +179,6 @@ aws_secret_access_key = p2_profile_access_key`
 			expSecretAccessKey: "p1_profile_access_key",
 		},
 		{
-
 			name:               "use a non-existent profile",
 			fileName:           file.Name(),
 			profileName:        "non-existent-profile",
@@ -698,7 +696,6 @@ func TestS3CopyEncryptionRequest(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			mockAPI := s3.New(unit.Session)
 
 			mockAPI.Handlers.Unmarshal.Clear()
@@ -707,7 +704,6 @@ func TestS3CopyEncryptionRequest(t *testing.T) {
 			mockAPI.Handlers.Send.Clear()
 
 			mockAPI.Handlers.Send.PushBack(func(r *request.Request) {
-
 				r.HTTPResponse = &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader("")),
@@ -751,7 +747,6 @@ func TestS3CopyEncryptionRequest(t *testing.T) {
 			metadata.ACL = tc.acl
 
 			err = mockS3.Copy(context.Background(), u, u, metadata)
-
 			if err != nil {
 				t.Errorf("Expected %v, but received %q", nil, err)
 			}
@@ -803,7 +798,6 @@ func TestS3PutEncryptionRequest(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			mockAPI := s3.New(unit.Session)
 
 			mockAPI.Handlers.Unmarshal.Clear()
@@ -812,7 +806,6 @@ func TestS3PutEncryptionRequest(t *testing.T) {
 			mockAPI.Handlers.Send.Clear()
 
 			mockAPI.Handlers.Send.PushBack(func(r *request.Request) {
-
 				r.HTTPResponse = &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader("")),
@@ -847,7 +840,6 @@ func TestS3PutEncryptionRequest(t *testing.T) {
 			metadata.ACL = tc.acl
 
 			err = mockS3.Put(context.Background(), bytes.NewReader([]byte("")), u, metadata, 1, 5242880)
-
 			if err != nil {
 				t.Errorf("Expected %v, but received %q", nil, err)
 			}
@@ -1273,7 +1265,6 @@ func TestS3HeadObject(t *testing.T) {
 			url:      "s3://another-bucket/another-key",
 			expected: "another-bucket/another-key",
 		},
-		// Add more test cases here
 	}
 
 	for _, tc := range testcases {

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -1257,45 +1257,6 @@ func TestAWSLogLevel(t *testing.T) {
 	}
 }
 
-func valueAtPath(i interface{}, s string) interface{} {
-	v, err := awsutil.ValuesAtPath(i, s)
-	if err != nil || len(v) == 0 {
-		return nil
-	}
-	if _, ok := v[0].(io.Reader); ok {
-		return v[0]
-	}
-
-	if rv := reflect.ValueOf(v[0]); rv.Kind() == reflect.Ptr {
-		return rv.Elem().Interface()
-	}
-
-	return v[0]
-}
-
-// tempError is a wrapper error type that implements anonymous
-// interface getting checked in url.Error.Temporary;
-//
-//	interface { Temporary() bool }
-//
-// see: https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/url/url.go#L38-L43
-//
-// AWS SDK checks if the underlying error in received url.Error implements it;
-// see: https://github.com/aws/aws-sdk-go/blob/b8fe768e4ce7f8f7c002bd7b27f4f5a8723fb1a5/aws/request/retryer.go#L191-L208
-//
-// It's used to mimic errors like tls.permanentError that would
-// be received in a url.Error when the connection timed out.
-type tempError struct {
-	err  error
-	temp bool
-}
-
-func (e tempError) Error() string { return e.err.Error() }
-
-func (e tempError) Temporary() bool { return e.temp }
-
-func (e *tempError) Unwrap() error { return e.err }
-
 func TestS3HeadObject(t *testing.T) {
 	testcases := []struct {
 		name     string
@@ -1350,3 +1311,42 @@ func TestS3HeadObject(t *testing.T) {
 		})
 	}
 }
+
+func valueAtPath(i interface{}, s string) interface{} {
+	v, err := awsutil.ValuesAtPath(i, s)
+	if err != nil || len(v) == 0 {
+		return nil
+	}
+	if _, ok := v[0].(io.Reader); ok {
+		return v[0]
+	}
+
+	if rv := reflect.ValueOf(v[0]); rv.Kind() == reflect.Ptr {
+		return rv.Elem().Interface()
+	}
+
+	return v[0]
+}
+
+// tempError is a wrapper error type that implements anonymous
+// interface getting checked in url.Error.Temporary;
+//
+//	interface { Temporary() bool }
+//
+// see: https://github.com/golang/go/blob/2ebe77a2fda1ee9ff6fd9a3e08933ad1ebaea039/src/net/url/url.go#L38-L43
+//
+// AWS SDK checks if the underlying error in received url.Error implements it;
+// see: https://github.com/aws/aws-sdk-go/blob/b8fe768e4ce7f8f7c002bd7b27f4f5a8723fb1a5/aws/request/retryer.go#L191-L208
+//
+// It's used to mimic errors like tls.permanentError that would
+// be received in a url.Error when the connection timed out.
+type tempError struct {
+	err  error
+	temp bool
+}
+
+func (e tempError) Error() string { return e.err.Error() }
+
+func (e tempError) Temporary() bool { return e.temp }
+
+func (e *tempError) Unwrap() error { return e.err }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,11 +18,8 @@ import (
 	"github.com/peak/s5cmd/v2/strutil"
 )
 
-var (
-
-	// ErrNoObjectFound indicates there are no objects found from a given directory.
-	ErrNoObjectFound = fmt.Errorf("no object found")
-)
+// ErrNoObjectFound indicates there are no objects found from a given directory.
+var ErrNoObjectFound = fmt.Errorf("no object found")
 
 // ErrGivenObjectNotFound indicates a specified object is not found.
 type ErrGivenObjectNotFound struct {

--- a/storage/url/url.go
+++ b/storage/url/url.go
@@ -399,6 +399,10 @@ func (u *URL) IsWildcard() bool {
 	return !u.raw && hasGlobCharacter(u.Path)
 }
 
+func (u *URL) IsRaw() bool {
+	return u.raw
+}
+
 // parseBatch parses keys for wildcard operations.
 // It cuts the key starting from first directory before the
 // wildcard part (filter)

--- a/storage/url/url.go
+++ b/storage/url/url.go
@@ -399,10 +399,6 @@ func (u *URL) IsWildcard() bool {
 	return !u.raw && hasGlobCharacter(u.Path)
 }
 
-func (u *URL) IsRaw() bool {
-	return u.raw
-}
-
 // parseBatch parses keys for wildcard operations.
 // It cuts the key starting from first directory before the
 // wildcard part (filter)


### PR DESCRIPTION
This pull request adds the `head` command to the program. Closes #682.

The `head` command is designed to check if a file exists without downloading the object or bucket itself. It retrieves metadata from an object without returning the object itself. This operation is useful for users who are only interested in an object's metadata.

- Implemented the head command functionality.
- Added end-point tests to ensure the correctness of the head command implementation.

Usage:

Check if a bucket exists
```
s5cmd head s3://bucket-name
```

Check if a file exists and retrieve its metadata

```
s5cmd head s3://bucket-name/object
```
