### PR TITLE
chore: prefer chan struct{} over chan bool for signalling

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -107,12 +107,12 @@ Examples:
 
 	22. Upload a file to S3 with a content-type and content-encoding header
 		 > s5cmd --content-type "text/css" --content-encoding "br" myfile.css.br s3://bucket/
-		 
+
 	23. Download the specific version of a remote object to working directory
 		 > s5cmd {{.HelpName}} --version-id VERSION_ID s3://bucket/prefix/object .
 
-	24. Pass arbitrary metadata to the object during upload or copy 
-		 > s5cmd {{.HelpName}} --metadata "camera=Nixon D750" --metadata "imageSize=6032x4032" flowers.png s3://bucket/prefix/flowers.png 
+	24. Pass arbitrary metadata to the object during upload or copy
+		 > s5cmd {{.HelpName}} --metadata "camera=Nixon D750" --metadata "imageSize=6032x4032" flowers.png s3://bucket/prefix/flowers.png
 `
 
 func NewSharedFlags() []cli.Flag {
@@ -425,7 +425,7 @@ func (c Copy) Run(ctx context.Context) error {
 	var (
 		merrorWaiter  error
 		merrorObjects error
-		errDoneCh     = make(chan bool)
+		errDoneCh     = make(chan struct{})
 	)
 
 	go func() {

--- a/command/run.go
+++ b/command/run.go
@@ -87,7 +87,7 @@ func (r Run) Run(ctx context.Context) error {
 
 	waiter := parallel.NewWaiter()
 
-	var errDoneCh = make(chan bool)
+	var errDoneCh = make(chan struct{})
 	var merrorWaiter error
 	go func() {
 		defer close(errDoneCh)

--- a/command/select.go
+++ b/command/select.go
@@ -28,15 +28,15 @@ Options:
 	{{range .VisibleFlags}}{{.}}
 	{{end}}
 Examples:
-	01. Select the average price of the avocado and amount sold, set the output format as csv 
+	01. Select the average price of the avocado and amount sold, set the output format as csv
 		 > s5cmd select csv -use-header USE --query "SELECT s.avg_price, s.quantity FROM S3Object s WHERE s.item='avocado'" "s3://bucket/prices.csv"
 
-	02. Query TSV files 
+	02. Query TSV files
 		 > s5cmd select csv --delimiter=\t --use-header USE --query "SELECT s.avg_price, s.quantity FROM S3Object s WHERE s.item='avocado'" "s3://bucket/prices.tsv"
 
-	03. Select a specific field in a JSON document 
+	03. Select a specific field in a JSON document
 		 > s5cmd select json --structure document --query "SELECT s.tracking_id FROM s3object[*]['metadata']['.zattrs'] s" "s3://bucket/metadata.json"
-	
+
 	04. Query files that contain lines of JSON objects
 		 > s5cmd select json --query "SELECT s.id FROM s3object s WHERE s.lineNumber = 1"
 `
@@ -310,8 +310,8 @@ func (s Select) Run(ctx context.Context) error {
 	)
 
 	waiter := parallel.NewWaiter()
-	errDoneCh := make(chan bool)
-	writeDoneCh := make(chan bool)
+	errDoneCh := make(chan struct{})
+	writeDoneCh := make(chan struct{})
 	resultCh := make(chan json.RawMessage, 128)
 
 	go func() {

--- a/command/sync.go
+++ b/command/sync.go
@@ -66,7 +66,7 @@ Examples:
 
 	10. Sync all files to S3 bucket but exclude the ones with txt and gz extension
 		 > s5cmd {{.HelpName}} --exclude "*.txt" --exclude "*.gz" dir/ s3://bucket
-	
+
 	11. Sync all files to S3 bucket but include the only ones with txt and gz extension
 		 > s5cmd {{.HelpName}} --include "*.txt" --include "*.gz" dir/ s3://bucket
 `
@@ -211,7 +211,7 @@ func (s Sync) Run(c *cli.Context) error {
 	waiter := parallel.NewWaiter()
 	var (
 		merrorWaiter error
-		errDoneCh    = make(chan bool)
+		errDoneCh    = make(chan struct{})
 	)
 
 	go func() {

--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -15,7 +15,7 @@ type Task func() error
 // Manager is a structure for running tasks in parallel.
 type Manager struct {
 	wg        *sync.WaitGroup
-	semaphore chan bool
+	semaphore chan struct{}
 }
 
 // New creates a new parallel.Manager.
@@ -30,13 +30,13 @@ func New(workercount int) *Manager {
 
 	return &Manager{
 		wg:        &sync.WaitGroup{},
-		semaphore: make(chan bool, workercount),
+		semaphore: make(chan struct{}, workercount),
 	}
 }
 
 // acquire limits concurrency by trying to acquire the semaphore.
 func (p *Manager) acquire() {
-	p.semaphore <- true
+	p.semaphore <- struct{}{}
 	p.wg.Add(1)
 }
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1061,7 +1061,7 @@ func (s *S3) MultiDelete(ctx context.Context, urlch <-chan *url.URL) <-chan *Obj
 	resultch := make(chan *Object)
 
 	go func() {
-		sem := make(chan bool, 10)
+		sem := make(chan struct{}, 10)
 		defer close(sem)
 		defer close(resultch)
 
@@ -1072,7 +1072,7 @@ func (s *S3) MultiDelete(ctx context.Context, urlch <-chan *url.URL) <-chan *Obj
 			chunk := chunk
 
 			wg.Add(1)
-			sem <- true
+			sem <- struct{}{}
 
 			go func() {
 				defer wg.Done()


### PR DESCRIPTION
Prefer using `chan struct{}` since:
- We are not interested in value being passed to channel, it is just used for signaling
- It occupies zero memory (bool:64bit)
- We used `chan struct{}` and `chan bool` interchangeably. To maintain a standard in the codebase, let's only use chan struct. 