### PR TITLE
fix: cp command S3toS3 --content-type flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added prefix and wildcard support to `cat` command. ([#716](https://github.com/peak/s5cmd/issues/716))
 - Added `head` command. ([#730](https://github.com/peak/s5cmd/pull/730))
 
+#### Bugfixes
+- Fixed `cp` command to flag to work with --content-type when performing a copy operation S3 to S3. ([#738](https://github.com/peak/s5cmd/issues/738))
+
 ## v2.2.2 - 13 Sep 2023 
 
 #### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added `head` command. ([#730](https://github.com/peak/s5cmd/pull/730))
 
 #### Bugfixes
-- Fixed `cp` command to flag to work with --content-type when performing a copy operation S3 to S3. ([#738](https://github.com/peak/s5cmd/issues/738))
+- Fixed the `cp` command to work with the `--content-type` flag when performing a copy operation from S3 to S3. ([#738](https://github.com/peak/s5cmd/issues/738))
 
 ## v2.2.2 - 13 Sep 2023 
 

--- a/command/cp.go
+++ b/command/cp.go
@@ -530,6 +530,10 @@ func (c Copy) Run(ctx context.Context) error {
 			if c.metadataDirective == "" {
 				// default to COPY
 				c.metadataDirective = "COPY"
+				if c.src.IsRemote() && c.dst.IsRemote() && c.contentType != "" {
+					// default to REPLACE for content type change
+					c.metadataDirective = "REPLACE"
+				}
 			}
 			task = c.prepareCopyTask(ctx, srcurl, c.dst, isBatch, c.metadata)
 		case srcurl.IsRemote(): // remote->local

--- a/command/cp.go
+++ b/command/cp.go
@@ -32,6 +32,11 @@ const (
 	kilobytes              = 1024
 )
 
+const (
+	metadataDirectiveCopy    = "COPY"
+	metadataDirectiveReplace = "REPLACE"
+)
+
 var copyHelpTemplate = `Name:
 	{{.HelpName}} - {{.Usage}}
 
@@ -145,7 +150,7 @@ func NewSharedFlags() []cli.Flag {
 			Name:  "metadata-directive",
 			Usage: "set metadata directive for the object: COPY or REPLACE",
 			Value: &EnumValue{
-				Enum:    []string{"COPY", "REPLACE", ""},
+				Enum:    []string{metadataDirectiveCopy, metadataDirectiveReplace, ""},
 				Default: "",
 				ConditionFunction: func(str, target string) bool {
 					return strings.EqualFold(target, str)
@@ -529,10 +534,10 @@ func (c Copy) Run(ctx context.Context) error {
 		case srcurl.Type == c.dst.Type: // local->local or remote->remote
 			if c.metadataDirective == "" {
 				// default to COPY
-				c.metadataDirective = "COPY"
-				if c.src.IsRemote() && c.dst.IsRemote() && c.contentType != "" {
-					// default to REPLACE for content type change
-					c.metadataDirective = "REPLACE"
+				c.metadataDirective = metadataDirectiveCopy
+				if c.src.IsRemote() && c.dst.IsRemote() {
+					// default to REPLACE when copying between remote storages
+					c.metadataDirective = metadataDirectiveReplace
 				}
 			}
 			task = c.prepareCopyTask(ctx, srcurl, c.dst, isBatch, c.metadata)

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4732,7 +4732,7 @@ func TestCopyMultipleS3ObjectsToAnotherBucketWithContentType(t *testing.T) {
 	createBucket(t, s3client, srcbucket)
 	createBucket(t, s3client, dstbucket)
 
-	files_and_content := map[string]string{
+	fileAndContent := map[string]string{
 		"file1.txt":                "this is a test file 1",
 		"file2.html":               "<html><body><h1>file2</h1></body></html>",
 		"file3.mp4":                "this is a test file 3",
@@ -4742,7 +4742,7 @@ func TestCopyMultipleS3ObjectsToAnotherBucketWithContentType(t *testing.T) {
 		"b/filename-with-hypen.gz": "file has hypen in its name",
 	}
 
-	for filename, content := range files_and_content {
+	for filename, content := range fileAndContent {
 		putFile(t, s3client, srcbucket, filename, content)
 	}
 
@@ -4756,15 +4756,15 @@ func TestCopyMultipleS3ObjectsToAnotherBucketWithContentType(t *testing.T) {
 
 	// assert s3
 	// these seperation is intentional to make it easier to debug.
-	for filename, content := range files_and_content {
+	for filename, content := range fileAndContent {
 		assert.Assert(t, ensureS3Object(s3client, srcbucket, filename, content))
 	}
 
-	for filename, content := range files_and_content {
+	for filename, content := range fileAndContent {
 		assert.Assert(t, ensureS3Object(s3client, dstbucket, filename, content))
 	}
 
-	for filename, content := range files_and_content {
+	for filename, content := range fileAndContent {
 		assert.Assert(t, ensureS3Object(s3client, dstbucket, filename, content, ensureContentType("video/avi")))
 	}
 }

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -866,7 +866,7 @@ func TestCopyS3ToS3WithArbitraryMetadataWithDefaultDirective(t *testing.T) {
 		"Key2": aws.String("value2"),
 	}
 
-	destmetadata := map[string]*string{
+	dstmetadata := map[string]*string{
 		"Key1": aws.String("foo"),
 		"Key2": aws.String("bar"),
 	}
@@ -881,7 +881,7 @@ func TestCopyS3ToS3WithArbitraryMetadataWithDefaultDirective(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	// assert S3
-	assert.Assert(t, ensureS3Object(s3client, bucket, fmt.Sprintf("%s_cp", filename), content, ensureArbitraryMetadata(destmetadata)))
+	assert.Assert(t, ensureS3Object(s3client, bucket, fmt.Sprintf("%s_cp", filename), content, ensureArbitraryMetadata(dstmetadata)))
 }
 
 // cp s3://bucket2/obj2 s3://bucket1/obj1 --metadata-directive REPLACE --metadata key1=val1 --metadata key2=val2 ...

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4635,10 +4635,10 @@ func TestCopySingleLocalFileToS3WithContentType(t *testing.T) {
 
 // cp --content-type "video/avi" dir s3://bucket/
 func TestCopyMultipleFilesToS3BucketWithContentType(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Files in Windows cannot contain glob(*) characters")
 	}
-	t.Parallel()
 
 	s3client, s5cmd := setup(t)
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -58,28 +58,28 @@ func TestCopySingleS3ObjectToLocal(t *testing.T) {
 			name:        "cp s3://bucket/object .",
 			src:         "file1.txt",
 			dst:         ".",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object file",
 			src:         "file1.txt",
 			dst:         "file1.txt",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object dir/",
 			src:         "file1.txt",
 			dst:         "dir/",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
 			expectedDst: "dir/file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object dir/file",
 			src:         "file1.txt",
 			dst:         "dir/file1.txt",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
 			expectedDst: "dir/file1.txt",
 		},
 		// Cases with adjacent slashes. Expected behavior is to remove all duplicate slashes in local files.
@@ -87,28 +87,28 @@ func TestCopySingleS3ObjectToLocal(t *testing.T) {
 			name:        "cp s3://bucket//a/b///c////object .",
 			src:         "/a/b///c////file1.txt",
 			dst:         ".",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object file",
 			src:         "/a/b///c////file1.txt",
 			dst:         "file1.txt",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object dir/",
 			src:         "/a/b///c////file1.txt",
 			dst:         "dir/",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
 			expectedDst: "dir/file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object dir/file",
 			src:         "/a/b///c////file1.txt",
 			dst:         "dir/file1.txt",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
 			expectedDst: "dir/file1.txt",
 		},
 	}
@@ -184,7 +184,7 @@ func TestCopySingleS3ObjectToLocalJSON(t *testing.T) {
 	}, jsonCheck(true))
 
 	// assert local filesystem
-	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0o644)))
+	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 
 	// assert s3 object
@@ -294,7 +294,7 @@ func TestCopyMultipleFlatS3ObjectsToLocal(t *testing.T) {
 
 	// assert local filesystem
 	// expect flattened directory structure
-	expectedFiles := []fs.PathOp{
+	var expectedFiles = []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithFile("readme.md", "this is a readme file"),
 		fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
@@ -341,8 +341,8 @@ func TestCopyMultipleFlatS3ObjectsToLocalWithPartialMatching(t *testing.T) {
 
 	// assert local filesystem
 	expectedFiles := []fs.PathOp{
-		fs.WithFile("testfile1.txt", "this is a test file 1", fs.WithMode(0o644)),
-		fs.WithFile("another_test_file.txt", "yet another txt file", fs.WithMode(0o644)),
+		fs.WithFile("testfile1.txt", "this is a test file 1", fs.WithMode(0644)),
+		fs.WithFile("another_test_file.txt", "yet another txt file", fs.WithMode(0644)),
 	}
 	expected := fs.Expected(t, expectedFiles...)
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
@@ -382,7 +382,7 @@ func TestCopyMultipleFlatNestedS3ObjectsToLocalWithPartialMatching(t *testing.T)
 	}, sortInput(true))
 
 	// assert local filesystem
-	expected := fs.Expected(t, fs.WithFile("testfile2.txt", "test file 2", fs.WithMode(0o644)))
+	expected := fs.Expected(t, fs.WithFile("testfile2.txt", "test file 2", fs.WithMode(0644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 
 	// assert s3 objects
@@ -469,7 +469,7 @@ func TestCopyMultipleFlatS3ObjectsToLocalJSON(t *testing.T) {
 
 	// assert local filesystem
 	// expect flattened directory structure
-	expectedFiles := []fs.PathOp{
+	var expectedFiles = []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithFile("readme.md", "this is a readme file"),
 		fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
@@ -519,7 +519,7 @@ func TestCopyMultipleNestedS3ObjectsToLocal(t *testing.T) {
 	}, sortInput(true))
 
 	// assert local filesystem
-	expectedFiles := []fs.PathOp{
+	var expectedFiles = []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithDir(
 			"a",
@@ -645,7 +645,7 @@ func TestCopyMultipleS3ObjectsToGivenLocalDirectory(t *testing.T) {
 	}, sortInput(true))
 
 	// assert local filesystem
-	expectedFiles := []fs.PathOp{
+	var expectedFiles = []fs.PathOp{
 		fs.WithDir(
 			"a",
 			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
@@ -787,6 +787,7 @@ func TestCopySingleFileToS3WithAllMetadataFlags(t *testing.T) {
 		ensureEncryptionMethod(EncryptionMethod),
 		ensureEncryptionKeyID(EncryptionKeyID),
 	))
+
 }
 
 // cp dir/file s3://bucket/ --metadata key1=val1 --metadata key2=val2 ...
@@ -991,6 +992,7 @@ func TestCopySingleFileToS3WithAdjacentSlashes(t *testing.T) {
 		})
 
 	}
+
 }
 
 // --json cp dir/file s3://bucket
@@ -1130,6 +1132,7 @@ func TestCopyDirBackslashedToS3(t *testing.T) {
 	// assert s3
 	assert.Assert(t, ensureS3Object(s3client, bucket, "readme.md", `¯\_(ツ)_/¯`))
 	assert.Assert(t, ensureS3Object(s3client, bucket, "t\\est/filetest.txt", "try reaching me on windows :-)"))
+
 }
 
 // cp --storage-class=GLACIER file s3://bucket/
@@ -2274,6 +2277,7 @@ func TestCopyMultipleS3ObjectsToS3WithPrefixWithoutSlash(t *testing.T) {
 	for filename, content := range filesToContent {
 		assert.Assert(t, ensureS3Object(s3client, bucket, filename, content))
 	}
+
 }
 
 // --json cp s3://bucket/* s3://bucket/prefix/
@@ -2612,9 +2616,9 @@ func TestCopyS3ToLocal_Issue70(t *testing.T) {
 	expectedFiles := []fs.PathOp{
 		fs.WithDir(
 			".local",
-			fs.WithMode(0o755),
-			fs.WithDir("folder1", fs.WithMode(0o755), fs.WithFile("file1.txt", "this is a test file 1")),
-			fs.WithDir("folder2", fs.WithMode(0o755), fs.WithFile("file2.txt", "this is a test file 2")),
+			fs.WithMode(0755),
+			fs.WithDir("folder1", fs.WithMode(0755), fs.WithFile("file1.txt", "this is a test file 1")),
+			fs.WithDir("folder2", fs.WithMode(0755), fs.WithFile("file2.txt", "this is a test file 2")),
 		),
 	}
 
@@ -2885,7 +2889,7 @@ func TestCopyLocalFileToS3WithFilePermissions(t *testing.T) {
 		content  = "this is the content"
 	)
 
-	fileModes := []os.FileMode{0o400, 0o440, 0o444, 0o600, 0o640, 0o644, 0o700, 0o750, 0o755}
+	fileModes := []os.FileMode{0400, 0440, 0444, 0600, 0640, 0644, 0700, 0750, 0755}
 
 	for _, fileMode := range fileModes {
 
@@ -3563,6 +3567,7 @@ func TestCopyS3ObjectstoLocalWithRawFlag(t *testing.T) {
 
 			for _, filename := range tc.src {
 				putFile(t, s3client, bucket, filename, fileContent)
+
 			}
 
 			cmd := s5cmd("cp", "s3://"+bucket+"/"+tc.wantedFile, ".")
@@ -3968,7 +3973,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 				assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
 			}
 
-			// assert objects should not be in S3.
+			//assert objects should not be in S3.
 			for key, content := range nonExpectedS3Content {
 				err := ensureS3Object(s3client, bucket, key, content)
 				assertError(t, err, errS3NoSuchKey)
@@ -4039,7 +4044,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilters(t *testing.T) {
 		assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
 	}
 
-	// assert objects should not be in S3.
+	//assert objects should not be in S3.
 	for key, content := range nonExpectedS3Content {
 		err := ensureS3Object(s3client, bucket, key, content)
 		assertError(t, err, errS3NoSuchKey)
@@ -4266,7 +4271,7 @@ func TestVersionedDownload(t *testing.T) {
 
 	const filename = "testfile.txt"
 
-	contents := []string{
+	var contents = []string{
 		"This is first content",
 		"Second content it is, and it is a bit longer!!!",
 	}
@@ -4388,7 +4393,7 @@ func TestCountingWriter(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	// assert the downloaded file has the same content with the remote object
-	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0o644)))
+	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 }
 

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4646,17 +4646,9 @@ func TestCopyMultipleFilesToS3BucketWithContentType(t *testing.T) {
 
 	folderLayout := []fs.PathOp{
 		fs.WithFile("file1.html", "<html><body><h1>file1</h1></body></html>"),
-		fs.WithFile("file2.text", "this is a test file 2"),
-		fs.WithFile("file3.mp4", "this is a test file 3"),
-		fs.WithFile("file4.py", "import tensorflow as tf"),
-		fs.WithFile("readme.md", "this is a readme file"),
 		fs.WithDir(
 			"a",
 			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
-		),
-		fs.WithDir(
-			"b",
-			fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
 		),
 	}
 
@@ -4678,22 +4670,12 @@ func TestCopyMultipleFilesToS3BucketWithContentType(t *testing.T) {
 	// assert lines
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: equals("cp %v/a/another_test_file.txt %sa/another_test_file.txt", workdir.Path(), dst),
-		1: equals("cp %v/b/filename-with-hypen.gz %sb/filename-with-hypen.gz", workdir.Path(), dst),
-		2: equals("cp %v/file1.html %sfile1.html", workdir.Path(), dst),
-		3: equals("cp %v/file2.text %sfile2.text", workdir.Path(), dst),
-		4: equals("cp %v/file3.mp4 %sfile3.mp4", workdir.Path(), dst),
-		5: equals("cp %v/file4.py %sfile4.py", workdir.Path(), dst),
-		6: equals("cp %v/readme.md %sreadme.md", workdir.Path(), dst),
+		1: equals("cp %v/file1.html %sfile1.html", workdir.Path(), dst),
 	}, sortInput(true))
 
 	// assert s3
 	assert.Assert(t, ensureS3Object(s3client, bucket, "file1.html", "<html><body><h1>file1</h1></body></html>", ensureContentType("video/avi")))
-	assert.Assert(t, ensureS3Object(s3client, bucket, "file2.text", "this is a test file 2", ensureContentType("video/avi")))
-	assert.Assert(t, ensureS3Object(s3client, bucket, "file3.mp4", "this is a test file 3", ensureContentType("video/avi")))
-	assert.Assert(t, ensureS3Object(s3client, bucket, "file4.py", "import tensorflow as tf", ensureContentType("video/avi")))
-	assert.Assert(t, ensureS3Object(s3client, bucket, "readme.md", "this is a readme file", ensureContentType("video/avi")))
 	assert.Assert(t, ensureS3Object(s3client, bucket, "a/another_test_file.txt", "yet another txt file. yatf.", ensureContentType("video/avi")))
-	assert.Assert(t, ensureS3Object(s3client, bucket, "b/filename-with-hypen.gz", "file has hypen in its name", ensureContentType("video/avi")))
 }
 
 // cp --content-type "video/avi" s3://srcbucket/object s3://dstbucket/
@@ -4741,13 +4723,8 @@ func TestCopyMultipleS3ObjectsToAnotherBucketWithContentType(t *testing.T) {
 	createBucket(t, s3client, dstbucket)
 
 	fileAndContent := map[string]string{
-		"file1.txt":                "this is a test file 1",
-		"file2.html":               "<html><body><h1>file2</h1></body></html>",
-		"file3.mp4":                "this is a test file 3",
-		"file4.py":                 "import tensorflow as tf",
-		"readme.md":                "this is a readme file",
-		"a/another_test_file.txt":  "yet another txt file. yatf.",
-		"b/filename-with-hypen.gz": "file has hypen in its name",
+		"file1.txt":               "this is a test file 1",
+		"a/another_test_file.txt": "yet another txt file. yatf.",
 	}
 
 	for filename, content := range fileAndContent {

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -58,28 +58,28 @@ func TestCopySingleS3ObjectToLocal(t *testing.T) {
 			name:        "cp s3://bucket/object .",
 			src:         "file1.txt",
 			dst:         ".",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object file",
 			src:         "file1.txt",
 			dst:         "file1.txt",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object dir/",
 			src:         "file1.txt",
 			dst:         "dir/",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
 			expectedDst: "dir/file1.txt",
 		},
 		{
 			name:        "cp s3://bucket/object dir/file",
 			src:         "file1.txt",
 			dst:         "dir/file1.txt",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
 			expectedDst: "dir/file1.txt",
 		},
 		// Cases with adjacent slashes. Expected behavior is to remove all duplicate slashes in local files.
@@ -87,28 +87,28 @@ func TestCopySingleS3ObjectToLocal(t *testing.T) {
 			name:        "cp s3://bucket//a/b///c////object .",
 			src:         "/a/b///c////file1.txt",
 			dst:         ".",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object file",
 			src:         "/a/b///c////file1.txt",
 			dst:         "file1.txt",
-			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0644)),
+			expected:    fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644)),
 			expectedDst: "file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object dir/",
 			src:         "/a/b///c////file1.txt",
 			dst:         "dir/",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
 			expectedDst: "dir/file1.txt",
 		},
 		{
 			name:        "cp s3://bucket//a/b///c////object dir/file",
 			src:         "/a/b///c////file1.txt",
 			dst:         "dir/file1.txt",
-			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0644))),
+			expected:    fs.WithDir("dir", fs.WithFile("file1.txt", fileContent, fs.WithMode(0o644))),
 			expectedDst: "dir/file1.txt",
 		},
 	}
@@ -184,7 +184,7 @@ func TestCopySingleS3ObjectToLocalJSON(t *testing.T) {
 	}, jsonCheck(true))
 
 	// assert local filesystem
-	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0644)))
+	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0o644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 
 	// assert s3 object
@@ -294,7 +294,7 @@ func TestCopyMultipleFlatS3ObjectsToLocal(t *testing.T) {
 
 	// assert local filesystem
 	// expect flattened directory structure
-	var expectedFiles = []fs.PathOp{
+	expectedFiles := []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithFile("readme.md", "this is a readme file"),
 		fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
@@ -341,8 +341,8 @@ func TestCopyMultipleFlatS3ObjectsToLocalWithPartialMatching(t *testing.T) {
 
 	// assert local filesystem
 	expectedFiles := []fs.PathOp{
-		fs.WithFile("testfile1.txt", "this is a test file 1", fs.WithMode(0644)),
-		fs.WithFile("another_test_file.txt", "yet another txt file", fs.WithMode(0644)),
+		fs.WithFile("testfile1.txt", "this is a test file 1", fs.WithMode(0o644)),
+		fs.WithFile("another_test_file.txt", "yet another txt file", fs.WithMode(0o644)),
 	}
 	expected := fs.Expected(t, expectedFiles...)
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
@@ -382,7 +382,7 @@ func TestCopyMultipleFlatNestedS3ObjectsToLocalWithPartialMatching(t *testing.T)
 	}, sortInput(true))
 
 	// assert local filesystem
-	expected := fs.Expected(t, fs.WithFile("testfile2.txt", "test file 2", fs.WithMode(0644)))
+	expected := fs.Expected(t, fs.WithFile("testfile2.txt", "test file 2", fs.WithMode(0o644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 
 	// assert s3 objects
@@ -469,7 +469,7 @@ func TestCopyMultipleFlatS3ObjectsToLocalJSON(t *testing.T) {
 
 	// assert local filesystem
 	// expect flattened directory structure
-	var expectedFiles = []fs.PathOp{
+	expectedFiles := []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithFile("readme.md", "this is a readme file"),
 		fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
@@ -519,7 +519,7 @@ func TestCopyMultipleNestedS3ObjectsToLocal(t *testing.T) {
 	}, sortInput(true))
 
 	// assert local filesystem
-	var expectedFiles = []fs.PathOp{
+	expectedFiles := []fs.PathOp{
 		fs.WithFile("testfile1.txt", "this is a test file 1"),
 		fs.WithDir(
 			"a",
@@ -645,7 +645,7 @@ func TestCopyMultipleS3ObjectsToGivenLocalDirectory(t *testing.T) {
 	}, sortInput(true))
 
 	// assert local filesystem
-	var expectedFiles = []fs.PathOp{
+	expectedFiles := []fs.PathOp{
 		fs.WithDir(
 			"a",
 			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
@@ -787,7 +787,6 @@ func TestCopySingleFileToS3WithAllMetadataFlags(t *testing.T) {
 		ensureEncryptionMethod(EncryptionMethod),
 		ensureEncryptionKeyID(EncryptionKeyID),
 	))
-
 }
 
 // cp dir/file s3://bucket/ --metadata key1=val1 --metadata key2=val2 ...
@@ -992,7 +991,6 @@ func TestCopySingleFileToS3WithAdjacentSlashes(t *testing.T) {
 		})
 
 	}
-
 }
 
 // --json cp dir/file s3://bucket
@@ -1132,7 +1130,6 @@ func TestCopyDirBackslashedToS3(t *testing.T) {
 	// assert s3
 	assert.Assert(t, ensureS3Object(s3client, bucket, "readme.md", `¯\_(ツ)_/¯`))
 	assert.Assert(t, ensureS3Object(s3client, bucket, "t\\est/filetest.txt", "try reaching me on windows :-)"))
-
 }
 
 // cp --storage-class=GLACIER file s3://bucket/
@@ -2277,7 +2274,6 @@ func TestCopyMultipleS3ObjectsToS3WithPrefixWithoutSlash(t *testing.T) {
 	for filename, content := range filesToContent {
 		assert.Assert(t, ensureS3Object(s3client, bucket, filename, content))
 	}
-
 }
 
 // --json cp s3://bucket/* s3://bucket/prefix/
@@ -2616,9 +2612,9 @@ func TestCopyS3ToLocal_Issue70(t *testing.T) {
 	expectedFiles := []fs.PathOp{
 		fs.WithDir(
 			".local",
-			fs.WithMode(0755),
-			fs.WithDir("folder1", fs.WithMode(0755), fs.WithFile("file1.txt", "this is a test file 1")),
-			fs.WithDir("folder2", fs.WithMode(0755), fs.WithFile("file2.txt", "this is a test file 2")),
+			fs.WithMode(0o755),
+			fs.WithDir("folder1", fs.WithMode(0o755), fs.WithFile("file1.txt", "this is a test file 1")),
+			fs.WithDir("folder2", fs.WithMode(0o755), fs.WithFile("file2.txt", "this is a test file 2")),
 		),
 	}
 
@@ -2889,7 +2885,7 @@ func TestCopyLocalFileToS3WithFilePermissions(t *testing.T) {
 		content  = "this is the content"
 	)
 
-	fileModes := []os.FileMode{0400, 0440, 0444, 0600, 0640, 0644, 0700, 0750, 0755}
+	fileModes := []os.FileMode{0o400, 0o440, 0o444, 0o600, 0o640, 0o644, 0o700, 0o750, 0o755}
 
 	for _, fileMode := range fileModes {
 
@@ -3567,7 +3563,6 @@ func TestCopyS3ObjectstoLocalWithRawFlag(t *testing.T) {
 
 			for _, filename := range tc.src {
 				putFile(t, s3client, bucket, filename, fileContent)
-
 			}
 
 			cmd := s5cmd("cp", "s3://"+bucket+"/"+tc.wantedFile, ".")
@@ -3973,7 +3968,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilter(t *testing.T) {
 				assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
 			}
 
-			//assert objects should not be in S3.
+			// assert objects should not be in S3.
 			for key, content := range nonExpectedS3Content {
 				err := ensureS3Object(s3client, bucket, key, content)
 				assertError(t, err, errS3NoSuchKey)
@@ -4044,7 +4039,7 @@ func TestCopyLocalDirectoryToS3WithExcludeFilters(t *testing.T) {
 		assert.Assert(t, ensureS3Object(s3client, bucket, key, content))
 	}
 
-	//assert objects should not be in S3.
+	// assert objects should not be in S3.
 	for key, content := range nonExpectedS3Content {
 		err := ensureS3Object(s3client, bucket, key, content)
 		assertError(t, err, errS3NoSuchKey)
@@ -4271,7 +4266,7 @@ func TestVersionedDownload(t *testing.T) {
 
 	const filename = "testfile.txt"
 
-	var contents = []string{
+	contents := []string{
 		"This is first content",
 		"Second content it is, and it is a bit longer!!!",
 	}
@@ -4393,7 +4388,7 @@ func TestCountingWriter(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	// assert the downloaded file has the same content with the remote object
-	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0644)))
+	expected := fs.Expected(t, fs.WithFile(filename, content, fs.WithMode(0o644)))
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
 }
 
@@ -4595,4 +4590,181 @@ func TestCopyS3ObjectsWithIncludeExcludeFilter2(t *testing.T) {
 	// assert local filesystem
 	expected := fs.Expected(t, expectedFileSystem...)
 	assert.Assert(t, fs.Equal(cmd.Dir, expected))
+}
+
+// cp --content-type "video/mp4" file s3://bucket/
+func TestCopySingleLocalFileToS3WithContentType(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	const (
+		filename = "testfile.txt"
+		content  = "this is a test file"
+	)
+
+	workdir := fs.NewDir(t, t.Name(), fs.WithFile(filename, content))
+	defer workdir.Remove()
+
+	srcpath := workdir.Join(filename)
+	dstpath := fmt.Sprintf("s3://%v/", bucket)
+
+	cmd := s5cmd("cp", "--content-type", "video/mp4", srcpath, dstpath)
+
+	result := icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+
+	// assert local filesystem
+	expected := fs.Expected(t, fs.WithFile(filename, content))
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	// assert s3
+	assert.Assert(t, ensureS3Object(s3client, bucket, filename, content, ensureContentType("video/mp4")))
+}
+
+// cp --content-type "video/avi" dir s3://bucket/
+func TestCopyMultipleFilesToS3BucketWithContentType(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	// create files with different content types
+
+	folderLayout := []fs.PathOp{
+		fs.WithFile("file1.html", "<html><body><h1>file1</h1></body></html>"),
+		fs.WithFile("file2.text", "this is a test file 2"),
+		fs.WithFile("file3.mp4", "this is a test file 3"),
+		fs.WithFile("file4.py", "import tensorflow as tf"),
+		fs.WithFile("readme.md", "this is a readme file"),
+		fs.WithDir(
+			"a",
+			fs.WithFile("another_test_file.txt", "yet another txt file. yatf."),
+		),
+		fs.WithDir(
+			"b",
+			fs.WithFile("filename-with-hypen.gz", "file has hypen in its name"),
+		),
+	}
+
+	workdir := fs.NewDir(t, "somedir", folderLayout...)
+	defer workdir.Remove()
+
+	src := fmt.Sprintf("%v/*", workdir.Path())
+	dst := fmt.Sprintf("s3://%v/", bucket)
+
+	cmd := s5cmd("cp", "--content-type", "video/avi", src, dst)
+
+	result := icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+
+	// assert local filesystem
+	expected := fs.Expected(t, folderLayout...)
+	assert.Assert(t, fs.Equal(workdir.Path(), expected))
+
+	// assert lines
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals("cp %v/a/another_test_file.txt %sa/another_test_file.txt", workdir.Path(), dst),
+		1: equals("cp %v/b/filename-with-hypen.gz %sb/filename-with-hypen.gz", workdir.Path(), dst),
+		2: equals("cp %v/file1.html %sfile1.html", workdir.Path(), dst),
+		3: equals("cp %v/file2.text %sfile2.text", workdir.Path(), dst),
+		4: equals("cp %v/file3.mp4 %sfile3.mp4", workdir.Path(), dst),
+		5: equals("cp %v/file4.py %sfile4.py", workdir.Path(), dst),
+		6: equals("cp %v/readme.md %sreadme.md", workdir.Path(), dst),
+	}, sortInput(true))
+
+	// assert s3
+	assert.Assert(t, ensureS3Object(s3client, bucket, "file1.html", "<html><body><h1>file1</h1></body></html>", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "file2.text", "this is a test file 2", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "file3.mp4", "this is a test file 3", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "file4.py", "import tensorflow as tf", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "readme.md", "this is a readme file", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "a/another_test_file.txt", "yet another txt file. yatf.", ensureContentType("video/avi")))
+	assert.Assert(t, ensureS3Object(s3client, bucket, "b/filename-with-hypen.gz", "file has hypen in its name", ensureContentType("video/avi")))
+}
+
+// cp --content-type "video/avi" s3://srcbucket/object s3://dstbucket/
+func TestCopySingleS3ObjectToAnotherBucketWithContentType(t *testing.T) {
+	t.Parallel()
+
+	srcbucket := s3BucketFromTestNameWithPrefix(t, "src")
+	dstbucket := s3BucketFromTestNameWithPrefix(t, "dst")
+
+	s3client, s5cmd := setup(t)
+
+	createBucket(t, s3client, srcbucket)
+	createBucket(t, s3client, dstbucket)
+
+	const (
+		filename = "testfile.txt"
+		content  = "this is a test file"
+	)
+
+	putFile(t, s3client, srcbucket, filename, content)
+
+	src := fmt.Sprintf("s3://%v/%v", srcbucket, filename)
+	dst := fmt.Sprintf("s3://%v/", dstbucket)
+
+	cmd := s5cmd("cp", "--content-type", "video/avi", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	// assert s3
+	assert.Assert(t, ensureS3Object(s3client, srcbucket, filename, content))
+	assert.Assert(t, ensureS3Object(s3client, dstbucket, filename, content, ensureContentType("video/avi")))
+}
+
+// cp --content-type "video/avi" s3://srcbucket/* s3://dstbucket/
+func TestCopyMultipleS3ObjectsToAnotherBucketWithContentType(t *testing.T) {
+	t.Parallel()
+
+	srcbucket := s3BucketFromTestNameWithPrefix(t, "src")
+	dstbucket := s3BucketFromTestNameWithPrefix(t, "dst")
+
+	s3client, s5cmd := setup(t)
+
+	createBucket(t, s3client, srcbucket)
+	createBucket(t, s3client, dstbucket)
+
+	files_and_content := map[string]string{
+		"file1.txt":                "this is a test file 1",
+		"file2.html":               "<html><body><h1>file2</h1></body></html>",
+		"file3.mp4":                "this is a test file 3",
+		"file4.py":                 "import tensorflow as tf",
+		"readme.md":                "this is a readme file",
+		"a/another_test_file.txt":  "yet another txt file. yatf.",
+		"b/filename-with-hypen.gz": "file has hypen in its name",
+	}
+
+	for filename, content := range files_and_content {
+		putFile(t, s3client, srcbucket, filename, content)
+	}
+
+	src := fmt.Sprintf("s3://%v/*", srcbucket)
+	dst := fmt.Sprintf("s3://%v/", dstbucket)
+
+	cmd := s5cmd("cp", "--content-type", "video/avi", src, dst)
+	result := icmd.RunCmd(cmd)
+
+	result.Assert(t, icmd.Success)
+
+	// assert s3
+	// these seperation is intentional to make it easier to debug.
+	for filename, content := range files_and_content {
+		assert.Assert(t, ensureS3Object(s3client, srcbucket, filename, content))
+	}
+
+	for filename, content := range files_and_content {
+		assert.Assert(t, ensureS3Object(s3client, dstbucket, filename, content))
+	}
+
+	for filename, content := range files_and_content {
+		assert.Assert(t, ensureS3Object(s3client, dstbucket, filename, content, ensureContentType("video/avi")))
+	}
 }

--- a/e2e/cp_test.go
+++ b/e2e/cp_test.go
@@ -4627,6 +4627,9 @@ func TestCopySingleLocalFileToS3WithContentType(t *testing.T) {
 
 // cp --content-type "video/avi" dir s3://bucket/
 func TestCopyMultipleFilesToS3BucketWithContentType(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Files in Windows cannot contain glob(*) characters")
+	}
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -554,9 +554,6 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 
 	if metadata.ContentType != "" {
 		input.ContentType = aws.String(metadata.ContentType)
-		if metadata.Directive == "" {
-			input.MetadataDirective = aws.String("REPLACE")
-		}
 	}
 
 	if len(metadata.UserDefined) != 0 {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -552,6 +552,13 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 		input.MetadataDirective = aws.String(metadata.Directive)
 	}
 
+	if metadata.ContentType != "" {
+		input.ContentType = aws.String(metadata.ContentType)
+		if metadata.Directive == "" {
+			input.MetadataDirective = aws.String("REPLACE")
+		}
+	}
+
 	if len(metadata.UserDefined) != 0 {
 		m := make(map[string]*string)
 		for k, v := range metadata.UserDefined {


### PR DESCRIPTION
In s5cmd, the --content-type flag does not work when performing an S3 to S3 copy operation with the cp command. 

Added tests addressing this issue.

resolves #738 