### PR TITLE
fix: fix single object cases for sync

### DIFF
--- a/command/sync.go
+++ b/command/sync.go
@@ -261,9 +261,8 @@ func compareObjects(sourceObjects, destObjects chan *storage.Object, isSrcBatch 
 
 		for {
 			if srcOk {
-				if isSrcBatch {
-					srcName = filepath.ToSlash(src.URL.Relative())
-				} else {
+				srcName = filepath.ToSlash(src.URL.Relative())
+				if !isSrcBatch {
 					srcName = src.URL.Base()
 				}
 			}

--- a/command/sync.go
+++ b/command/sync.go
@@ -203,7 +203,7 @@ func (s Sync) Run(c *cli.Context) error {
 		isBatch = obj != nil && obj.Type.IsDir()
 	}
 
-	onlySource, onlyDest, commonObjects := compareObjects(sourceObjects, destObjects)
+	onlySource, onlyDest, commonObjects := compareObjects(sourceObjects, destObjects, isBatch)
 
 	sourceObjects = nil
 	destObjects = nil
@@ -242,7 +242,7 @@ func (s Sync) Run(c *cli.Context) error {
 // sourceObjects and destObjects channels are already sorted in ascending order.
 // Returns objects those in only source, only destination
 // and both.
-func compareObjects(sourceObjects, destObjects chan *storage.Object) (chan *url.URL, chan *url.URL, chan *ObjectPair) {
+func compareObjects(sourceObjects, destObjects chan *storage.Object, isSrcBatch bool) (chan *url.URL, chan *url.URL, chan *ObjectPair) {
 	var (
 		srcOnly   = make(chan *url.URL, extsortChannelBufferSize)
 		dstOnly   = make(chan *url.URL, extsortChannelBufferSize)
@@ -261,7 +261,11 @@ func compareObjects(sourceObjects, destObjects chan *storage.Object) (chan *url.
 
 		for {
 			if srcOk {
-				srcName = filepath.ToSlash(src.URL.Relative())
+				if isSrcBatch {
+					srcName = filepath.ToSlash(src.URL.Relative())
+				} else {
+					srcName = src.URL.Base()
+				}
 			}
 			if dstOk {
 				dstName = filepath.ToSlash(dst.URL.Relative())

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -91,6 +91,100 @@ func TestSyncSingleS3ObjectToLocalTwice(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 }
 
+// sync s3://bucket/dir/source.go .
+func TestSyncSingleS3ObjectFromDirToLocal(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		dirname  = "dir"
+		filename = "source.go"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, fmt.Sprintf("%s/%s", dirname, filename), "content")
+
+	srcpath := fmt.Sprintf("s3://%s/%s/%s", bucket, dirname, filename)
+
+	cmd := s5cmd("sync", srcpath, ".")
+	result := icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v %v`, srcpath, filename),
+	})
+
+	// rerunning same command should not download object, empty result expected
+	result = icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
+// sync s3://bucket/dir/source.go folder/
+func TestSyncSingleS3ObjectFromDirToLocalDir(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		dirname  = "dir"
+		filename = "source.go"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, fmt.Sprintf("%s/%s", dirname, filename), "content")
+
+	srcpath := fmt.Sprintf("s3://%s/%s/%s", bucket, dirname, filename)
+	dstpath := "folder/"
+
+	cmd := s5cmd("sync", srcpath, dstpath)
+	result := icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v %v/%v`, srcpath, dstpath, filename),
+	})
+
+	// rerunning same command should not download object, empty result expected
+	result = icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
+// sync s3://bucket/source.go folder/
+func TestSyncSingleS3ObjectToLocalDir(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		filename = "source.go"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+	putFile(t, s3client, bucket, filename, "content")
+
+	srcpath := fmt.Sprintf("s3://%s/%s", bucket, filename)
+	dstpath := "folder/"
+
+	cmd := s5cmd("sync", srcpath, dstpath)
+	result := icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v %v/%v`, srcpath, dstpath, filename),
+	})
+
+	// rerunning same command should not download object, empty result expected
+	result = icmd.RunCmd(cmd)
+	result.Assert(t, icmd.Success)
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
 // sync file s3://bucket
 func TestSyncLocalFileToS3Twice(t *testing.T) {
 	t.Parallel()
@@ -118,6 +212,116 @@ func TestSyncLocalFileToS3Twice(t *testing.T) {
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
 		0: equals(`cp %v %v/%v`, filename, dstpath, filename),
+	})
+
+	// rerunning same command should not upload files, empty result expected
+	result = icmd.RunCmd(cmd, withWorkingDir(workdir))
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
+// sync file s3://bucket/dir/
+func TestSyncLocalFileToS3Dir(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		filename = "testfile1.txt"
+		content  = "this is the content"
+		dirname  = "dir"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	workdir := fs.NewDir(t, t.Name(), fs.WithFile(filename, content))
+	defer workdir.Remove()
+
+	dstpath := fmt.Sprintf("s3://%v/%v", bucket, dirname)
+
+	cmd := s5cmd("sync", filename, dstpath)
+	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v %v/%v`, filename, dstpath, filename),
+	})
+
+	// rerunning same command should not upload files, empty result expected
+	result = icmd.RunCmd(cmd, withWorkingDir(workdir))
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
+// sync dir/file s3://bucket
+func TestSyncLocalDirFileToS3(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		dirname  = "dir"
+		filename = "testfile1.txt"
+		content  = "this is the content"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	workdir := fs.NewDir(t, t.Name(), fs.WithDir(dirname, fs.WithFile(filename, content)))
+	defer workdir.Remove()
+
+	srcpath := fmt.Sprintf("%v/%v", dirname, filename)
+	dstpath := fmt.Sprintf("s3://%v", bucket)
+
+	cmd := s5cmd("sync", srcpath, dstpath)
+	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v/%v %v/%v`, dirname, filename, dstpath, filename),
+	})
+
+	// rerunning same command should not upload files, empty result expected
+	result = icmd.RunCmd(cmd, withWorkingDir(workdir))
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{})
+}
+
+// sync dir/file s3://bucket/dir/
+func TestSyncLocalDirFileToS3Dir(t *testing.T) {
+	t.Parallel()
+
+	s3client, s5cmd := setup(t)
+
+	const (
+		dirname  = "dir"
+		filename = "testfile1.txt"
+		content  = "this is the content"
+	)
+
+	bucket := s3BucketFromTestName(t)
+	createBucket(t, s3client, bucket)
+
+	workdir := fs.NewDir(t, t.Name(), fs.WithDir(dirname, fs.WithFile(filename, content)))
+	defer workdir.Remove()
+
+	srcpath := fmt.Sprintf("%v/%v", dirname, filename)
+	dstpath := fmt.Sprintf("s3://%v/%v", bucket, dirname)
+
+	cmd := s5cmd("sync", srcpath, dstpath)
+	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
+
+	result.Assert(t, icmd.Success)
+
+	assertLines(t, result.Stdout(), map[int]compareFunc{
+		0: equals(`cp %v/%v %v/%v`, dirname, filename, dstpath, filename),
 	})
 
 	// rerunning same command should not upload files, empty result expected

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -92,7 +92,7 @@ func TestSyncSingleS3ObjectToLocalTwice(t *testing.T) {
 }
 
 // sync s3://bucket/dir/source.go .
-func TestSyncSingleS3ObjectFromDirToLocal(t *testing.T) {
+func TestSyncSinglePrefixedS3ObjectToCurrentDirectory(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -122,8 +122,8 @@ func TestSyncSingleS3ObjectFromDirToLocal(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 }
 
-// sync s3://bucket/dir/source.go folder/
-func TestSyncSingleS3ObjectFromDirToLocalDir(t *testing.T) {
+// sync s3://bucket/prefix/source.go dir/
+func TestSyncPrefixedSingleS3ObjectToLocalDirectory(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -154,8 +154,8 @@ func TestSyncSingleS3ObjectFromDirToLocalDir(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 }
 
-// sync s3://bucket/source.go folder/
-func TestSyncSingleS3ObjectToLocalDir(t *testing.T) {
+// sync s3://bucket/source.go dir/
+func TestSyncSingleS3ObjectToLocalDirectory(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -221,8 +221,8 @@ func TestSyncLocalFileToS3Twice(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 }
 
-// sync file s3://bucket/dir/
-func TestSyncLocalFileToS3Dir(t *testing.T) {
+// sync file s3://bucket/prefix/
+func TestSyncLocalFileToS3Prefix(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -258,7 +258,7 @@ func TestSyncLocalFileToS3Dir(t *testing.T) {
 }
 
 // sync dir/file s3://bucket
-func TestSyncLocalDirFileToS3(t *testing.T) {
+func TestSyncLocalFileInDirectoryToS3(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)
@@ -294,8 +294,8 @@ func TestSyncLocalDirFileToS3(t *testing.T) {
 	assertLines(t, result.Stdout(), map[int]compareFunc{})
 }
 
-// sync dir/file s3://bucket/dir/
-func TestSyncLocalDirFileToS3Dir(t *testing.T) {
+// sync dir/file s3://bucket/prefix/
+func TestSyncLocalFileInDirectoryToS3Prefix(t *testing.T) {
 	t.Parallel()
 
 	s3client, s5cmd := setup(t)

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -138,9 +138,9 @@ func TestSyncSingleS3ObjectFromDirToLocalDir(t *testing.T) {
 	putFile(t, s3client, bucket, fmt.Sprintf("%s/%s", dirname, filename), "content")
 
 	srcpath := fmt.Sprintf("s3://%s/%s/%s", bucket, dirname, filename)
-	dstpath := "folder/"
+	dstpath := "folder"
 
-	cmd := s5cmd("sync", srcpath, dstpath)
+	cmd := s5cmd("sync", srcpath, fmt.Sprintf("%v/", dstpath))
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
@@ -169,9 +169,9 @@ func TestSyncSingleS3ObjectToLocalDir(t *testing.T) {
 	putFile(t, s3client, bucket, filename, "content")
 
 	srcpath := fmt.Sprintf("s3://%s/%s", bucket, filename)
-	dstpath := "folder/"
+	dstpath := "folder"
 
-	cmd := s5cmd("sync", srcpath, dstpath)
+	cmd := s5cmd("sync", srcpath, fmt.Sprintf("%v/", dstpath))
 	result := icmd.RunCmd(cmd)
 	result.Assert(t, icmd.Success)
 
@@ -241,7 +241,7 @@ func TestSyncLocalFileToS3Dir(t *testing.T) {
 
 	dstpath := fmt.Sprintf("s3://%v/%v", bucket, dirname)
 
-	cmd := s5cmd("sync", filename, dstpath)
+	cmd := s5cmd("sync", filename, fmt.Sprintf("%v/", dstpath))
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	result.Assert(t, icmd.Success)
@@ -315,7 +315,7 @@ func TestSyncLocalDirFileToS3Dir(t *testing.T) {
 	srcpath := fmt.Sprintf("%v/%v", dirname, filename)
 	dstpath := fmt.Sprintf("s3://%v/%v", bucket, dirname)
 
-	cmd := s5cmd("sync", srcpath, dstpath)
+	cmd := s5cmd("sync", srcpath, fmt.Sprintf("%v/", dstpath))
 	result := icmd.RunCmd(cmd, withWorkingDir(workdir))
 
 	result.Assert(t, icmd.Success)


### PR DESCRIPTION
The problem is mainly caused by the `compareObjects` function inside `command/sync.go`, where `s5cmd` compares source and destination paths and extracts files that are present only in the source or destination path (while also counting nested folders or rather name with its prefixes) along with common objects. If they both are non-objects, like wildcard expression, prefix, or bucket, getting relative paths of files with `src.URL.Relative()` results in compatible and comparable paths. In this case, no problem is present, at least within the scope of this issue.

However, when an object is selected as the source, it is not assigned a relative path using `func (u *url.URL) SetRelative(base *url.URL)`, so the `src.URL.Relative()` function returns its absolute path.

Let's say the source file has an absolute path of `folder/foo.txt`. The algorithm compares `folder/foo.txt` with `s3://bucket/remoteFolder/` and looks for the item `s3://bucket/remoteFolder/folder/foo.txt`. If it does not match, except for the edge case where there is a duplicate item inside the searched path, the files never match.

While copying files, `s5cmd` does not use relative paths, so `foo.txt` is written to the intended path in the remote. However, this happens during every sync operation, as they do not match.

Problem solved by taking path of source object as its name. This made algorithm to simply look for matches in destination, a file named `foo.txt` as intended. 

This PR adds new test cases to the sync command. Previously, tests failed to capture sync command cases where the source is an object in a prefix, not an object directly in a bucket, or not multiple objects like a wildcard or prefix expression. 

If an object is in the `s3://bucket/` path, its relative path is the same as its absolute path, so they match during comparison. This prevented copying the file every time. The new test cases cover all scenarios.
Resolves: https://github.com/peak/s5cmd/issues/676.