### PR TITLE
feat: optional --range argument for cp to download single part of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ You can also install `s5cmd` from [MacPorts](https://ports.macports.org/port/s5c
 > conda config --add channels conda-forge
 > conda config --set channel_priority strict
 > ```
-> 
+>
 > Once the `conda-forge` channel has been enabled, `s5cmd` can be installed with `conda`:
-> 
+>
 > ```
 > conda install s5cmd
 > ```
@@ -319,7 +319,7 @@ folder hierarchy.
 an [open ticket](https://github.com/peak/s5cmd/issues/29) to track the issue.
 
 #### Using Exclude and Include Filters
-`s5cmd` supports the `--exclude` and `--include` flags, which can be used to specify patterns for objects to be excluded or included in commands. 
+`s5cmd` supports the `--exclude` and `--include` flags, which can be used to specify patterns for objects to be excluded or included in commands.
 
 - The `--exclude` flag specifies objects that should be excluded from the operation. Any object that matches the pattern will be skipped.
 - The `--include` flag specifies objects that should be included in the operation. Only objects that match the pattern will be handled.
@@ -540,7 +540,7 @@ The environment variable `SHELL` must be accurate for the autocompletion to func
 The autocompletion is tested with following versions of the shells: \
 ***zsh*** 5.8.1 (x86_64-apple-darwin21.0) \
 GNU ***bash***, version 5.1.16(1)-release (x86_64-apple-darwin21.1.0) \
-***PowerShell*** 7.2.6 
+***PowerShell*** 7.2.6
 
 ### Google Cloud Storage support
 
@@ -686,6 +686,14 @@ s5cmd --numworkers 10 cp --concurrency 10 '/Users/foo/bar/*' s3://mybucket/foo/b
 ```
 
 If you have a few, large files to download, setting `--numworkers` to a very high value will not affect download speed. In this scenario setting `--concurrency` to a higher value may have a better impact on the download speed.
+
+### range
+
+`range` is a `cp` command option that targets only a specific byterange in the source object to download. This parameter is used by the AWS Go SDK (setting the [Range header](https://www.rfc-editor.org/rfc/rfc9110.html#name-range) in the GET request). Passing `range` option to `cp` will override any `--concurrency` or `--part_size` arguments (1 thread will be used to download this 1 part in the byterange).
+
+```
+s5cmd cp --range bytes=500-999 's3://mybucket/foo/bar/file.txt' partialFile.txt
+```
 
 ## Benchmarks
 Some benchmarks regarding the performance of `s5cmd` are introduced below. For more

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ If you have a few, large files to download, setting `--numworkers` to a very hig
 
 ### range
 
-`range` is a `cp` command option that targets only a specific byterange in the source object to download. This parameter is used by the AWS Go SDK (setting the [Range header](https://www.rfc-editor.org/rfc/rfc9110.html#name-range) in the GET request). Passing `range` option to `cp` will override any `--concurrency` or `--part_size` arguments (1 thread will be used to download this 1 part in the byterange).
+`range` is a `cp` command option that targets only a specific byterange in the source object to download. This parameter is used by the AWS Go SDK (setting the [Range header](https://www.rfc-editor.org/rfc/rfc9110.html#name-range) in the GET request). Passing `range` option to `cp` will override any `--concurrency` or `--part_size` arguments (1 thread will be used to download this 1 part specified by the byterange).
 
 ```
 s5cmd cp --range bytes=500-999 's3://mybucket/foo/bar/file.txt' partialFile.txt

--- a/command/cat.go
+++ b/command/cat.go
@@ -150,7 +150,7 @@ func (c Cat) processObjects(ctx context.Context, client *storage.S3, objectChan 
 
 func (c Cat) processSingleObject(ctx context.Context, client *storage.S3, url *url.URL) error {
 	buf := orderedwriter.New(os.Stdout)
-	_, err := client.Get(ctx, url, buf, c.concurrency, c.partSize)
+	_, err := client.Get(ctx, url, buf, c.concurrency, c.partSize, nil)
 	return err
 }
 

--- a/command/cp.go
+++ b/command/cp.go
@@ -406,7 +406,7 @@ func NewCopy(c *cli.Context, deleteSource bool) (*Copy, error) {
 		contentType:           c.String("content-type"),
 		contentEncoding:       c.String("content-encoding"),
 		contentDisposition:    c.String("content-disposition"),
-		contentRange:					 c.String("range"),
+		contentRange:          c.String("range"),
 		metadata:              metadata,
 		metadataDirective:     c.String("metadata-directive"),
 		showProgress:          c.Bool("show-progress"),

--- a/command/cp.go
+++ b/command/cp.go
@@ -118,6 +118,9 @@ Examples:
 
 	24. Pass arbitrary metadata to the object during upload or copy
 		 > s5cmd {{.HelpName}} --metadata "camera=Nixon D750" --metadata "imageSize=6032x4032" flowers.png s3://bucket/prefix/flowers.png
+
+  25. Copy only a specific byte range out of an S3 object.
+     > s5cmd {{.HelpName}} --range bytes=500-999 s3://bucket/prefix/object .
 `
 
 func NewSharedFlags() []cli.Flag {

--- a/command/cp.go
+++ b/command/cp.go
@@ -327,7 +327,7 @@ type Copy struct {
 	contentType           string
 	contentEncoding       string
 	contentDisposition    string
-	contentRange					string
+	contentRange          string
 	metadata              map[string]string
 	metadataDirective     string
 	showProgress          bool

--- a/command/cp.go
+++ b/command/cp.go
@@ -252,6 +252,10 @@ func NewCopyCommandFlags() []cli.Flag {
 			Name:  "version-id",
 			Usage: "use the specified version of an object",
 		},
+		&cli.StringFlag{
+			Name:  "range",
+			Usage: "defines range header for target object, e.g. --range bytes=0-100",
+		},
 		&cli.BoolFlag{
 			Name:    "show-progress",
 			Aliases: []string{"sp"},
@@ -320,6 +324,7 @@ type Copy struct {
 	contentType           string
 	contentEncoding       string
 	contentDisposition    string
+	contentRange					string
 	metadata              map[string]string
 	metadataDirective     string
 	showProgress          bool
@@ -398,6 +403,7 @@ func NewCopy(c *cli.Context, deleteSource bool) (*Copy, error) {
 		contentType:           c.String("content-type"),
 		contentEncoding:       c.String("content-encoding"),
 		contentDisposition:    c.String("content-disposition"),
+		contentRange:					 c.String("range"),
 		metadata:              metadata,
 		metadataDirective:     c.String("metadata-directive"),
 		showProgress:          c.Bool("show-progress"),
@@ -665,7 +671,7 @@ func (c Copy) doDownload(ctx context.Context, srcurl *url.URL, dsturl *url.URL) 
 	}
 
 	writer := newCountingReaderWriter(file, c.progressbar)
-	size, err := srcClient.Get(ctx, srcurl, writer, c.concurrency, c.partSize)
+	size, err := srcClient.Get(ctx, srcurl, writer, c.concurrency, c.partSize, &c.contentRange)
 	file.Close()
 
 	if err != nil {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -543,11 +543,6 @@ func (s *S3) Copy(ctx context.Context, from, to *url.URL, metadata Metadata) err
 		input.ContentDisposition = aws.String(contentDisposition)
 	}
 
-	// TODO: does this even exist for CopyObject?
-	// if metadata.Range != "" {
-	// 	input.Range = aws.String(metadata.Range)
-	// }
-
 	// add retry ID to the object metadata
 	if s.noSuchUploadRetryCount > 0 {
 		input.Metadata[metadataKeyRetryID] = generateRetryID()


### PR DESCRIPTION
Adds an optional string argument `--range` to `cp` command, which exposes the existing AWS [GetObject Range header](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax) to provide a specific byterange of the object to be copied. 

Now s5cmd users can optionally set this header manually and only download a specific part of their src object.

Example:
```
s5cmd cp --range bytes=500-999 's3://mybucket/foo/bar/file.txt' my_partial_file.txt
```

Obviously makes any `--concurrency` or `--part_size` arguments redundant when `--range` is specified, since only 1 part will be downloaded, using only 1 thread.

Note: AWS GetObject only supports specifying a single byte range, so we are also constrained by this limitation. An s5cmd user would have to run multiple `cp` commands to download, for example, bytes ranging from 100-199 (`bytes=100-199`) and from 300-399 (`bytes=300-399`).

Solves this Issue: https://github.com/peak/s5cmd/issues/756