### PR TITLE
Clarify statement in sync --include  example

### DIFF
--- a/command/sync.go
+++ b/command/sync.go
@@ -67,7 +67,7 @@ Examples:
 	10. Sync all files to S3 bucket but exclude the ones with txt and gz extension
 		 > s5cmd {{.HelpName}} --exclude "*.txt" --exclude "*.gz" dir/ s3://bucket
 
-	11. Sync all files to S3 bucket but include the only ones with txt and gz extension
+	11. Sync all files with txt and gz extensions (only) to S3 bucket
 		 > s5cmd {{.HelpName}} --include "*.txt" --include "*.gz" dir/ s3://bucket
 `
 


### PR DESCRIPTION
Unlike with "all ... but exclude" I think "all ... but include" makes less sense.