### PR TITLE
readme: install s5cmd from homebrew/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ binaries for Linux, macOS and Windows.
 
 For macOS, a [homebrew](https://brew.sh) tap is provided:
 
-    brew install peak/tap/s5cmd
+    brew install s5cmd
 
 ### Unofficial Releases (by Community)
 [![Packaging status](https://repology.org/badge/tiny-repos/s5cmd.svg)](https://repology.org/project/s5cmd/versions)


### PR DESCRIPTION
`s5cmd` has been added to `homebrew/core` in https://github.com/Homebrew/homebrew-core/pull/201377, and can be installed using `brew install s5cmd`.

Given there's https://github.com/peak/homebrew-tap the following actions can be:
- Adjust the PR, move `brew install s5cmd` to "Unofficial Releases (by Community)" and keep `brew install peak/tap/s5cmd` as the main command.
- Deprecate tap and add `tap_migrations.json` (with `{ "s5cmd": "homebrew/core" }`), which will redirect current users to `homebrew/core` installation
 