### PR TITLE
fix: skip stat call when progress bar is disabled

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -521,7 +521,7 @@ func (c Copy) Run(ctx context.Context) error {
 		srcurl := object.URL
 		var task parallel.Task
 
-		if object.Size == 0 && !(srcurl.Type == c.dst.Type) {
+		if _, ok := c.progressbar.(*progressbar.CommandProgressBar); ok && object.Size == 0 && srcurl.Type != c.dst.Type {
 			obj, err := client.Stat(ctx, srcurl)
 			if err == nil {
 				object.Size = obj.Size


### PR DESCRIPTION
This PR fixes unnecessary headObject calls in the cp command when the progress bar is disabled. It ensures `Client.stat` (headObject when copying remote->local) is only called when the progress bar is explicitly enabled, reducing latency and costs for bulk operations.

Changes:

Added a conditional check to skip `Client.stat` unless the progress bar is active.

Only requests object size when necessary, improving performance and cost efficiency for cp operations.

Closes #792.