### PR TITLE
feature: add extra virtual host style endpoints support

### DIFF
--- a/command/app.go
+++ b/command/app.go
@@ -90,10 +90,14 @@ var app = &cli.App{
 			Name:  "credentials-file",
 			Usage: "use the specified credentials file instead of the default credentials file",
 		},
-		&cli.StringFlag{
-			Name:    "support-virtual-host-style-endpoints",
-			Usage:   "add extra endpoints that support virtual host style requests, delimited by comma",
-			EnvVars: []string{"S3_SUPPORT_VIRTUAL_HOST_STYLE_ENDPOINTS"},
+		&cli.GenericFlag{
+			Name:  "addressing-style",
+			Usage: "use virtual host style or path style endpoint: (path, virtual)",
+			Value: &EnumValue{
+				Enum:    []string{"path", "virtual"},
+				Default: "path",
+			},
+			EnvVars: []string{"S3_ADDRESSING_STYLE"},
 		},
 	},
 	Before: func(c *cli.Context) error {
@@ -184,18 +188,18 @@ var app = &cli.App{
 // NewStorageOpts creates storage.Options object from the given context.
 func NewStorageOpts(c *cli.Context) storage.Options {
 	return storage.Options{
-		DryRun:                           c.Bool("dry-run"),
-		Endpoint:                         c.String("endpoint-url"),
-		MaxRetries:                       c.Int("retry-count"),
-		NoSignRequest:                    c.Bool("no-sign-request"),
-		NoVerifySSL:                      c.Bool("no-verify-ssl"),
-		RequestPayer:                     c.String("request-payer"),
-		UseListObjectsV1:                 c.Bool("use-list-objects-v1"),
-		Profile:                          c.String("profile"),
-		CredentialFile:                   c.String("credentials-file"),
-		LogLevel:                         log.LevelFromString(c.String("log")),
-		NoSuchUploadRetryCount:           c.Int("no-such-upload-retry-count"),
-		SupportVirtualHostStyleEndpoints: c.String("support-virtual-host-style-endpoints"),
+		DryRun:                 c.Bool("dry-run"),
+		Endpoint:               c.String("endpoint-url"),
+		MaxRetries:             c.Int("retry-count"),
+		NoSignRequest:          c.Bool("no-sign-request"),
+		NoVerifySSL:            c.Bool("no-verify-ssl"),
+		RequestPayer:           c.String("request-payer"),
+		UseListObjectsV1:       c.Bool("use-list-objects-v1"),
+		Profile:                c.String("profile"),
+		CredentialFile:         c.String("credentials-file"),
+		LogLevel:               log.LevelFromString(c.String("log")),
+		NoSuchUploadRetryCount: c.Int("no-such-upload-retry-count"),
+		AddressingStyle:        c.String("addressing-style"),
 	}
 }
 

--- a/command/app.go
+++ b/command/app.go
@@ -90,6 +90,11 @@ var app = &cli.App{
 			Name:  "credentials-file",
 			Usage: "use the specified credentials file instead of the default credentials file",
 		},
+		&cli.StringFlag{
+			Name:    "support-virtual-host-style-endpoints",
+			Usage:   "add extra endpoints that support virtual host style requests, delimited by comma",
+			EnvVars: []string{"S3_SUPPORT_VIRTUAL_HOST_STYLE_ENDPOINTS"},
+		},
 	},
 	Before: func(c *cli.Context) error {
 		retryCount := c.Int("retry-count")
@@ -179,17 +184,18 @@ var app = &cli.App{
 // NewStorageOpts creates storage.Options object from the given context.
 func NewStorageOpts(c *cli.Context) storage.Options {
 	return storage.Options{
-		DryRun:                 c.Bool("dry-run"),
-		Endpoint:               c.String("endpoint-url"),
-		MaxRetries:             c.Int("retry-count"),
-		NoSignRequest:          c.Bool("no-sign-request"),
-		NoVerifySSL:            c.Bool("no-verify-ssl"),
-		RequestPayer:           c.String("request-payer"),
-		UseListObjectsV1:       c.Bool("use-list-objects-v1"),
-		Profile:                c.String("profile"),
-		CredentialFile:         c.String("credentials-file"),
-		LogLevel:               log.LevelFromString(c.String("log")),
-		NoSuchUploadRetryCount: c.Int("no-such-upload-retry-count"),
+		DryRun:                           c.Bool("dry-run"),
+		Endpoint:                         c.String("endpoint-url"),
+		MaxRetries:                       c.Int("retry-count"),
+		NoSignRequest:                    c.Bool("no-sign-request"),
+		NoVerifySSL:                      c.Bool("no-verify-ssl"),
+		RequestPayer:                     c.String("request-payer"),
+		UseListObjectsV1:                 c.Bool("use-list-objects-v1"),
+		Profile:                          c.String("profile"),
+		CredentialFile:                   c.String("credentials-file"),
+		LogLevel:                         log.LevelFromString(c.String("log")),
+		NoSuchUploadRetryCount:           c.Int("no-such-upload-retry-count"),
+		SupportVirtualHostStyleEndpoints: c.String("support-virtual-host-style-endpoints"),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	if err := command.Main(ctx, os.Args); err != nil {
-		log.Printf("error: %v", err)
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -12,8 +13,8 @@ import (
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-
 	if err := command.Main(ctx, os.Args); err != nil {
+		log.Printf("error: %v", err)
 		os.Exit(1)
 	}
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -50,6 +50,8 @@ const (
 
 	// the key of the object metadata which is used to handle retry decision on NoSuchUpload error
 	metadataKeyRetryID = "s5cmd-upload-retry-id"
+
+	AddressingVirtualHostStyle = "virtual"
 )
 
 // Re-used AWS sessions dramatically improve performance.
@@ -1255,7 +1257,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 
 	// use virtual-host-style if the endpoint is known to support it,
 	// otherwise use the path-style approach.
-	isVirtualHostStyle := isVirtualHostStyle(endpointURL, opts.SupportVirtualHostStyleEndpoints)
+	isVirtualHostStyle := isVirtualHostStyle(endpointURL, opts.AddressingStyle)
 
 	useAccelerate := supportsTransferAcceleration(endpointURL)
 	// AWS SDK handles transfer acceleration automatically. Setting the
@@ -1422,24 +1424,18 @@ func IsGoogleEndpoint(endpoint urlpkg.URL) bool {
 	return endpoint.Hostname() == gcsEndpoint
 }
 
-func IsOtherVirtualHostStyleEndpoint(endpoint urlpkg.URL, supportVirtualHostStyleEndpoints string) bool {
-	supportVirtualHostStyleEndpointsSlice := strings.Split(supportVirtualHostStyleEndpoints, ",")
-	for _, supportVirtualHostStyleEndpoint := range supportVirtualHostStyleEndpointsSlice {
-		if endpoint.Hostname() == supportVirtualHostStyleEndpoint {
-			return true
-		}
-	}
-	return false
+func ForcedVirtualHostStyle(endpoint urlpkg.URL, addressingStyle string) bool {
+	return addressingStyle == AddressingVirtualHostStyle
 }
 
 // isVirtualHostStyle reports whether the given endpoint supports S3 virtual
 // host style bucket name resolving. If a custom S3 API compatible endpoint is
 // given, resolve the bucketname from the URL path.
-func isVirtualHostStyle(endpoint urlpkg.URL, supportVirtualHostStyleEndpoints string) bool {
+func isVirtualHostStyle(endpoint urlpkg.URL, addressingStyle string) bool {
 	return endpoint == sentinelURL ||
 		supportsTransferAcceleration(endpoint) ||
 		IsGoogleEndpoint(endpoint) ||
-		IsOtherVirtualHostStyleEndpoint(endpoint, supportVirtualHostStyleEndpoints)
+		ForcedVirtualHostStyle(endpoint, addressingStyle)
 }
 
 func errHasCode(err error, code string) bool {

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1255,7 +1255,7 @@ func (sc *SessionCache) newSession(ctx context.Context, opts Options) (*session.
 
 	// use virtual-host-style if the endpoint is known to support it,
 	// otherwise use the path-style approach.
-	isVirtualHostStyle := isVirtualHostStyle(endpointURL)
+	isVirtualHostStyle := isVirtualHostStyle(endpointURL, opts.SupportVirtualHostStyleEndpoints)
 
 	useAccelerate := supportsTransferAcceleration(endpointURL)
 	// AWS SDK handles transfer acceleration automatically. Setting the
@@ -1422,11 +1422,24 @@ func IsGoogleEndpoint(endpoint urlpkg.URL) bool {
 	return endpoint.Hostname() == gcsEndpoint
 }
 
+func IsOtherVirtualHostStyleEndpoint(endpoint urlpkg.URL, supportVirtualHostStyleEndpoints string) bool {
+	supportVirtualHostStyleEndpointsSlice := strings.Split(supportVirtualHostStyleEndpoints, ",")
+	for _, supportVirtualHostStyleEndpoint := range supportVirtualHostStyleEndpointsSlice {
+		if endpoint.Hostname() == supportVirtualHostStyleEndpoint {
+			return true
+		}
+	}
+	return false
+}
+
 // isVirtualHostStyle reports whether the given endpoint supports S3 virtual
 // host style bucket name resolving. If a custom S3 API compatible endpoint is
 // given, resolve the bucketname from the URL path.
-func isVirtualHostStyle(endpoint urlpkg.URL) bool {
-	return endpoint == sentinelURL || supportsTransferAcceleration(endpoint) || IsGoogleEndpoint(endpoint)
+func isVirtualHostStyle(endpoint urlpkg.URL, supportVirtualHostStyleEndpoints string) bool {
+	return endpoint == sentinelURL ||
+		supportsTransferAcceleration(endpoint) ||
+		IsGoogleEndpoint(endpoint) ||
+		IsOtherVirtualHostStyleEndpoint(endpoint, supportVirtualHostStyleEndpoints)
 }
 
 func errHasCode(err error, code string) bool {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -58,20 +58,20 @@ func NewLocalClient(opts Options) *Filesystem {
 
 func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, error) {
 	newOpts := Options{
-		MaxRetries:                       opts.MaxRetries,
-		NoSuchUploadRetryCount:           opts.NoSuchUploadRetryCount,
-		Endpoint:                         opts.Endpoint,
-		NoVerifySSL:                      opts.NoVerifySSL,
-		DryRun:                           opts.DryRun,
-		NoSignRequest:                    opts.NoSignRequest,
-		UseListObjectsV1:                 opts.UseListObjectsV1,
-		RequestPayer:                     opts.RequestPayer,
-		Profile:                          opts.Profile,
-		CredentialFile:                   opts.CredentialFile,
-		LogLevel:                         opts.LogLevel,
-		bucket:                           url.Bucket,
-		region:                           opts.region,
-		SupportVirtualHostStyleEndpoints: opts.SupportVirtualHostStyleEndpoints,
+		MaxRetries:             opts.MaxRetries,
+		NoSuchUploadRetryCount: opts.NoSuchUploadRetryCount,
+		Endpoint:               opts.Endpoint,
+		NoVerifySSL:            opts.NoVerifySSL,
+		DryRun:                 opts.DryRun,
+		NoSignRequest:          opts.NoSignRequest,
+		UseListObjectsV1:       opts.UseListObjectsV1,
+		RequestPayer:           opts.RequestPayer,
+		Profile:                opts.Profile,
+		CredentialFile:         opts.CredentialFile,
+		LogLevel:               opts.LogLevel,
+		bucket:                 url.Bucket,
+		region:                 opts.region,
+		AddressingStyle:        opts.AddressingStyle,
 	}
 	return newS3Storage(ctx, newOpts)
 }
@@ -85,20 +85,20 @@ func NewClient(ctx context.Context, url *url.URL, opts Options) (Storage, error)
 
 // Options stores configuration for storage.
 type Options struct {
-	MaxRetries                       int
-	NoSuchUploadRetryCount           int
-	Endpoint                         string
-	NoVerifySSL                      bool
-	DryRun                           bool
-	NoSignRequest                    bool
-	UseListObjectsV1                 bool
-	LogLevel                         log.LogLevel
-	RequestPayer                     string
-	Profile                          string
-	CredentialFile                   string
-	bucket                           string
-	region                           string
-	SupportVirtualHostStyleEndpoints string
+	MaxRetries             int
+	NoSuchUploadRetryCount int
+	Endpoint               string
+	NoVerifySSL            bool
+	DryRun                 bool
+	NoSignRequest          bool
+	UseListObjectsV1       bool
+	LogLevel               log.LogLevel
+	RequestPayer           string
+	Profile                string
+	CredentialFile         string
+	bucket                 string
+	region                 string
+	AddressingStyle        string
 }
 
 func (o *Options) SetRegion(region string) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -58,19 +58,20 @@ func NewLocalClient(opts Options) *Filesystem {
 
 func NewRemoteClient(ctx context.Context, url *url.URL, opts Options) (*S3, error) {
 	newOpts := Options{
-		MaxRetries:             opts.MaxRetries,
-		NoSuchUploadRetryCount: opts.NoSuchUploadRetryCount,
-		Endpoint:               opts.Endpoint,
-		NoVerifySSL:            opts.NoVerifySSL,
-		DryRun:                 opts.DryRun,
-		NoSignRequest:          opts.NoSignRequest,
-		UseListObjectsV1:       opts.UseListObjectsV1,
-		RequestPayer:           opts.RequestPayer,
-		Profile:                opts.Profile,
-		CredentialFile:         opts.CredentialFile,
-		LogLevel:               opts.LogLevel,
-		bucket:                 url.Bucket,
-		region:                 opts.region,
+		MaxRetries:                       opts.MaxRetries,
+		NoSuchUploadRetryCount:           opts.NoSuchUploadRetryCount,
+		Endpoint:                         opts.Endpoint,
+		NoVerifySSL:                      opts.NoVerifySSL,
+		DryRun:                           opts.DryRun,
+		NoSignRequest:                    opts.NoSignRequest,
+		UseListObjectsV1:                 opts.UseListObjectsV1,
+		RequestPayer:                     opts.RequestPayer,
+		Profile:                          opts.Profile,
+		CredentialFile:                   opts.CredentialFile,
+		LogLevel:                         opts.LogLevel,
+		bucket:                           url.Bucket,
+		region:                           opts.region,
+		SupportVirtualHostStyleEndpoints: opts.SupportVirtualHostStyleEndpoints,
 	}
 	return newS3Storage(ctx, newOpts)
 }
@@ -84,19 +85,20 @@ func NewClient(ctx context.Context, url *url.URL, opts Options) (Storage, error)
 
 // Options stores configuration for storage.
 type Options struct {
-	MaxRetries             int
-	NoSuchUploadRetryCount int
-	Endpoint               string
-	NoVerifySSL            bool
-	DryRun                 bool
-	NoSignRequest          bool
-	UseListObjectsV1       bool
-	LogLevel               log.LogLevel
-	RequestPayer           string
-	Profile                string
-	CredentialFile         string
-	bucket                 string
-	region                 string
+	MaxRetries                       int
+	NoSuchUploadRetryCount           int
+	Endpoint                         string
+	NoVerifySSL                      bool
+	DryRun                           bool
+	NoSignRequest                    bool
+	UseListObjectsV1                 bool
+	LogLevel                         log.LogLevel
+	RequestPayer                     string
+	Profile                          string
+	CredentialFile                   string
+	bucket                           string
+	region                           string
+	SupportVirtualHostStyleEndpoints string
 }
 
 func (o *Options) SetRegion(region string) {


### PR DESCRIPTION
This PR add the user custom endpoints that need to send request with virtual host style 

reference issues:
#794 
#518 

Here I add a command line flag and also support fetch config from environment variable, 

`  --addressing-style value       use virtual host style or path style endpoint: (path, virtual) (default: path) `

the address-style config is compatible with the aws s3 cli config，here is the aws document , and you can just search the address_style key word in the page.    https://docs.aws.amazon.com/cli/latest/topic/s3-config.html

```bash
NAME:
   s5cmd - Blazing fast S3 and local filesystem execution tool

USAGE:
   s5cmd [global options] command [command options] [arguments...]

COMMANDS:
   ls              list buckets and objects
   cp              copy objects
   rm              remove objects
   mv              move/rename objects
   mb              make bucket
   rb              remove bucket
   select          run SQL queries on objects
   du              show object size usage
   cat             print remote object content
   pipe            stream to remote from stdin
   run             run commands in batch
   sync            sync objects
   version         print version
   bucket-version  configure bucket versioning
   presign         print remote object presign url
   head            print remote object metadata
   help, h         Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --addressing-style value       use virtual host style or path style endpoint: (path, virtual) (default: path) [$S3_ADDRESSING_STYLE]
   --credentials-file value       use the specified credentials file instead of the default credentials file
   --dry-run                      fake run; show what commands will be executed without actually executing them (default: false)
   --endpoint-url value           override default S3 host for custom services [$S3_ENDPOINT_URL]
   --help, -h                     show help (default: false)
   --install-completion           get completion installation instructions for your shell (only available for bash, pwsh, and zsh) (default: false)
   --json                         enable JSON formatted output (default: false)
   --log value                    log level: (trace, debug, info, error) (default: info)
   --no-sign-request              do not sign requests: credentials will not be loaded if --no-sign-request is provided (default: false)
   --no-verify-ssl                disable SSL certificate verification (default: false)
   --numworkers value             number of workers execute operation on each object (default: 256)
   --profile value                use the specified profile from the credentials file
   --request-payer value          who pays for request (access requester pays buckets)
   --retry-count value, -r value  number of times that a request will be retried for failures (default: 10)
   --stat                         collect statistics of program execution and display it at the end (default: false)
   --use-list-objects-v1          use ListObjectsV1 API for services that don't support ListObjectsV2 (default: false)
```

And I well tested it, using this on our daily work, no bug being found till now.

I can give a example here :

1. If I want to upload a file to remote object storage , Firstly, I need to set up config with environment variable

```bash
export AWS_ACCESS_KEY_ID='xxxxxxxxxxx'
export AWS_SECRET_ACCESS_KEY='xxxxxxxxxx'
export S3_ENDPOINT_URL='http://oss-cn-hangzhou.aliyuncs.com'
```

1. Secondly, because I want to sent request with virtual host style, I need a another env  or command line flag

```bash
export S3_ADDRESSING_STYLE="virtual"      
```

1. Now you can upload or down load file with the s5cmd command 

```bash
/s5cmd cp ./testfile s3://restic-backup-good/hello/
or I can run:
/s5cmd  --addressing-style=virtual cp ./testfile s3://restic-backup-good/hello/

output:
cp ./testfile s3://restic-backup-good/hello/testfile 
```

let’s see the request detail on wireshark.  it just send the request with virtual host style ,  a bucket name as prefix of host 

![image](https://github.com/user-attachments/assets/898f6f73-e26e-443d-a863-c4f78c97b7fb)
