### PR TITLE
feature: add sync by hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,17 @@ src > dst  |  src = dst   |  ❌
 src <= dst  |  src != dst  |  ✅
 src <= dst  |  src == dst  |  ❌
 
+###### Hash only
+With `--hash-only` flag, it's possible to use the strategy that would only compare file sizes and hashes. Source treated as **source of truth** and any difference in sizes or hashes would cause `s5cmd` to copy source object to destination. Multipart upload will always sync the file.
+
+The hash can be stored remotely or calculated locally. If `s5cmd` calculate the hash from a local file, it performs many operations. To perform these operations in parallel and quickly, the `sync` uses the `numworkers` flag. As many `numworkers` are specified, as many threads will be created to calculate the hash.
+
+hash        |  size        |  should sync
+------------|--------------|-------------
+src != dst  |  src == dst  |  ✅
+src != dst  |  src != dst  |  ✅
+src == dst  |  src == dst  |  ❌
+
 ### Dry run
 `--dry-run` flag will output what operations will be performed without actually
 carrying out those operations.
@@ -673,6 +684,8 @@ For example, if you are uploading 100 files to an S3 bucket and the `--numworker
 ```
 s5cmd --numworkers 10 cp '/Users/foo/bar/*' s3://mybucket/foo/bar/
 ```
+
+Additionally, this flag is used to calculate hashes when using `sync` operation with `--hash-only` flag.
 
 ### concurrency
 

--- a/command/sync.go
+++ b/command/sync.go
@@ -52,22 +52,25 @@ Examples:
 	05. Sync S3 bucket to local folder but use size as only comparison criteria.
 		 > s5cmd {{.HelpName}} --size-only "s3://bucket/*" folder/
 
-	06. Sync a file to S3 bucket
+	06. Sync S3 bucket to local folder but use size and hash as comparasion criteria.
+		 > s5cmd {{.HelpName}} --hash-only "s3://bucket/*" folder/
+
+	07. Sync a file to S3 bucket
 		 > s5cmd {{.HelpName}} myfile.gz s3://bucket/
 
-	07. Sync matching S3 objects to another bucket
+	08. Sync matching S3 objects to another bucket
 		 > s5cmd {{.HelpName}} "s3://bucket/*.gz" s3://target-bucket/prefix/
 
-	08. Perform KMS Server Side Encryption of the object(s) at the destination
+	09. Perform KMS Server Side Encryption of the object(s) at the destination
 		 > s5cmd {{.HelpName}} --sse aws:kms s3://bucket/object s3://target-bucket/prefix/object
 
-	09. Perform KMS-SSE of the object(s) at the destination using customer managed Customer Master Key (CMK) key id
+	10. Perform KMS-SSE of the object(s) at the destination using customer managed Customer Master Key (CMK) key id
 		 > s5cmd {{.HelpName}} --sse aws:kms --sse-kms-key-id <your-kms-key-id> s3://bucket/object s3://target-bucket/prefix/object
 
-	10. Sync all files to S3 bucket but exclude the ones with txt and gz extension
+	11. Sync all files to S3 bucket but exclude the ones with txt and gz extension
 		 > s5cmd {{.HelpName}} --exclude "*.txt" --exclude "*.gz" dir/ s3://bucket
 
-	11. Sync all files to S3 bucket but include the only ones with txt and gz extension
+	12. Sync all files to S3 bucket but include the only ones with txt and gz extension
 		 > s5cmd {{.HelpName}} --include "*.txt" --include "*.gz" dir/ s3://bucket
 `
 
@@ -80,6 +83,10 @@ func NewSyncCommandFlags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:  "size-only",
 			Usage: "make size of object only criteria to decide whether an object should be synced",
+		},
+		&cli.BoolFlag{
+			Name:  "hash-only",
+			Usage: "make hash and size of object only criteria to decide whether an object should be synced",
 		},
 		&cli.BoolFlag{
 			Name:  "exit-on-error",
@@ -130,6 +137,7 @@ type Sync struct {
 	// flags
 	delete      bool
 	sizeOnly    bool
+	hashOnly    bool
 	exitOnError bool
 
 	// s3 options
@@ -154,6 +162,7 @@ func NewSync(c *cli.Context) Sync {
 		// flags
 		delete:      c.Bool("delete"),
 		sizeOnly:    c.Bool("size-only"),
+		hashOnly:    c.Bool("hash-only"),
 		exitOnError: c.Bool("exit-on-error"),
 
 		// flags
@@ -228,8 +237,8 @@ func (s Sync) Run(c *cli.Context) error {
 		}
 	}()
 
-	strategy := NewStrategy(s.sizeOnly) // create comparison strategy.
-	pipeReader, pipeWriter := io.Pipe() // create a reader, writer pipe to pass commands to run
+	strategy := NewStrategy(s.sizeOnly, s.hashOnly) // create comparison strategy.
+	pipeReader, pipeWriter := io.Pipe()             // create a reader, writer pipe to pass commands to run
 
 	// Create commands in background.
 	go s.planRun(c, onlySource, onlyDest, commonObjects, dsturl, strategy, pipeWriter, isBatch)
@@ -474,26 +483,30 @@ func (s Sync) planRun(
 	}()
 
 	// both in source and destination
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for commonObject := range common {
-			sourceObject, destObject := commonObject.src, commonObject.dst
-			curSourceURL, curDestURL := sourceObject.URL, destObject.URL
-			err := strategy.ShouldSync(sourceObject, destObject) // check if object should be copied.
-			if err != nil {
-				printDebug(s.op, err, curSourceURL, curDestURL)
-				continue
-			}
+	numWorkers := 6
+	// needs several goroutines because HashSync reads a lot of files from the file system
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for commonObject := range common {
+				sourceObject, destObject := commonObject.src, commonObject.dst
+				curSourceURL, curDestURL := sourceObject.URL, destObject.URL
+				err := strategy.ShouldSync(sourceObject, destObject) // check if object should be copied.
+				if err != nil {
+					printDebug(s.op, err, curSourceURL, curDestURL)
+					continue
+				}
 
-			command, err := generateCommand(c, "cp", defaultFlags, curSourceURL, curDestURL)
-			if err != nil {
-				printDebug(s.op, err, curSourceURL, curDestURL)
-				continue
+				command, err := generateCommand(c, "cp", defaultFlags, curSourceURL, curDestURL)
+				if err != nil {
+					printDebug(s.op, err, curSourceURL, curDestURL)
+					continue
+				}
+				fmt.Fprintln(w, command)
 			}
-			fmt.Fprintln(w, command)
-		}
-	}()
+		}()
+	}
 
 	// only in destination
 	wg.Add(1)

--- a/command/sync_strategy.go
+++ b/command/sync_strategy.go
@@ -91,7 +91,7 @@ func getHash(obj *storage.Object) string {
 	} else {
 		// cp.go opens the file again. It MAY be possible not to open the file again to calculate the hash.
 		// fs.go Stat loads file metadata. It is possible to calculate md5 hash in that place, but not necessary.
-		file, err := os.OpenFile(obj.URL.String(), os.O_RDONLY, 0644) // os.Open(srcObj.String())
+		file, err := os.OpenFile(obj.URL.String(), os.O_RDONLY, 0644)
 		// Can't open source file? Push it to the storage.
 		// Not sure about this place. Maybe should throw exception and stop execution.
 		// But if can't open file here, then can't open file in cp and upload it.
@@ -101,8 +101,7 @@ func getHash(obj *storage.Object) string {
 		defer file.Close()
 
 		var md5Obj = md5.New()
-		// buffer size depends on size of syncing files. It can be less or more than 256.
-		buf := make([]byte, 256*1024)
+		buf := make([]byte, obj.Size)
 		if _, err := io.CopyBuffer(md5Obj, file, buf); err != nil {
 			return ""
 		}

--- a/command/sync_strategy.go
+++ b/command/sync_strategy.go
@@ -1,6 +1,11 @@
 package command
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"os"
+
 	errorpkg "github.com/peak/s5cmd/v2/error"
 	"github.com/peak/s5cmd/v2/storage"
 )
@@ -11,9 +16,11 @@ type SyncStrategy interface {
 	ShouldSync(srcObject, dstObject *storage.Object) error
 }
 
-func NewStrategy(sizeOnly bool) SyncStrategy {
+func NewStrategy(sizeOnly bool, hashOnly bool) SyncStrategy {
 	if sizeOnly {
 		return &SizeOnlyStrategy{}
+	} else if hashOnly {
+		return &HashStrategy{}
 	} else {
 		return &SizeAndModificationStrategy{}
 	}
@@ -49,4 +56,57 @@ func (sm *SizeAndModificationStrategy) ShouldSync(srcObj, dstObj *storage.Object
 	}
 
 	return errorpkg.ErrObjectIsNewerAndSizesMatch
+}
+
+// HashStrategy determines to sync based on objects' hashes and sizes.
+// It treats source object as the source-of-truth; Source object can be local file or remote (s3).
+//
+//	md5 hash: src 		!= dst			should sync: yes
+//	md5 hash: src 		== dst			should sync: no
+//	md5 hash: src multipart upload		should sync: yes (always)
+//	md5 hash: can't open src			should sync: yes (but cp won't be able to open the file)
+type HashStrategy struct{}
+
+func (s *HashStrategy) ShouldSync(srcObj, dstObj *storage.Object) error {
+	// Firstly check size. Maybe the sizes will be different.
+	if srcObj.Size != dstObj.Size {
+		return nil
+	}
+
+	srcHash := getHash(srcObj)
+	dstHash := getHash(dstObj)
+
+	if srcHash == dstHash {
+		return errorpkg.ErrObjectEtagsMatch
+	}
+
+	return nil
+}
+
+func getHash(obj *storage.Object) string {
+	// if remote (s3) then should has Etag
+	// if not remote (s3) but has Etag then return it
+	if obj.URL.IsRemote() || obj.Etag != "" {
+		return obj.Etag
+	} else {
+		// cp.go opens the file again. It MAY be possible not to open the file again to calculate the hash.
+		// fs.go Stat loads file metadata. It is possible to calculate md5 hash in that place, but not necessary.
+		file, err := os.OpenFile(obj.URL.String(), os.O_RDONLY, 0644) // os.Open(srcObj.String())
+		// Can't open source file? Push it to the storage.
+		// Not sure about this place. Maybe should throw exception and stop execution.
+		// But if can't open file here, then can't open file in cp and upload it.
+		if err != nil {
+			return ""
+		}
+		defer file.Close()
+
+		var md5Obj = md5.New()
+		// buffer size depends on size of syncing files. It can be less or more than 256.
+		buf := make([]byte, 256*1024)
+		if _, err := io.CopyBuffer(md5Obj, file, buf); err != nil {
+			return ""
+		}
+
+		return hex.EncodeToString(md5Obj.Sum(nil))
+	}
 }

--- a/error/error.go
+++ b/error/error.go
@@ -77,6 +77,9 @@ var (
 	// ErrObjectSizesMatch indicates the sizes of objects match.
 	ErrObjectSizesMatch = fmt.Errorf("object size matches")
 
+	// ErrObjectEtagsMatch indicates the Etag of objects match.
+	ErrObjectEtagsMatch = fmt.Errorf("object ETag maches")
+
 	// ErrObjectIsNewerAndSizesMatch indicates the specified object is newer or same age and sizes of objects match.
 	ErrObjectIsNewerAndSizesMatch = fmt.Errorf("%v and %v", ErrObjectIsNewer, ErrObjectSizesMatch)
 
@@ -88,7 +91,7 @@ var (
 // ErrObjectIsNewer or ErrObjectSizesMatch.
 func IsWarning(err error) bool {
 	switch err {
-	case ErrObjectExists, ErrObjectIsNewer, ErrObjectSizesMatch, ErrObjectIsNewerAndSizesMatch, ErrorObjectIsGlacier:
+	case ErrObjectExists, ErrObjectIsNewer, ErrObjectSizesMatch, ErrObjectEtagsMatch, ErrObjectIsNewerAndSizesMatch, ErrorObjectIsGlacier:
 		return true
 	}
 

--- a/error/error.go
+++ b/error/error.go
@@ -78,7 +78,7 @@ var (
 	ErrObjectSizesMatch = fmt.Errorf("object size matches")
 
 	// ErrObjectEtagsMatch indicates the Etag of objects match.
-	ErrObjectEtagsMatch = fmt.Errorf("object ETag maches")
+	ErrObjectEtagsMatch = fmt.Errorf("object ETag matches")
 
 	// ErrObjectIsNewerAndSizesMatch indicates the specified object is newer or same age and sizes of objects match.
 	ErrObjectIsNewerAndSizesMatch = fmt.Errorf("%v and %v", ErrObjectIsNewer, ErrObjectSizesMatch)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -242,6 +242,9 @@ func (o Object) ToBytes() []byte {
 	enc.Encode(o.ModTime.Format(time.RFC3339Nano))
 	enc.Encode(o.Type.mode)
 	enc.Encode(o.Size)
+	// Needs to compare source and destination file by ETag.
+	// We can add flag "NeedETag" to save only when needed.
+	enc.Encode(o.Etag)
 
 	return buf.Bytes()
 }
@@ -260,6 +263,11 @@ func FromBytes(data []byte) extsort.SortType {
 	o.ModTime = &tmp
 	dec.Decode(&o.Type.mode)
 	dec.Decode(&o.Size)
+	// Needs to compare source and destination file by ETag.
+	// fs.go Filesystem Stat saves empty ("") Etag value. This means that there is no point to decode this value here.
+	// We can add flag "NeedETag" to save only when needed.
+	dec.Decode(&o.Etag)
+
 	return o
 }
 


### PR DESCRIPTION
# Implemented directory synchronization using the hash strategy

When using this tool, I encountered the following problem:

1. There are two build machines: `b1` and `b2`. Each machine has its own local build cache. Both machines upload data to the same MinIO/S3 bucket.  
2. During the build on machine `b1`, files are generated with an `mtime` of `13:00`. These files are uploaded to an empty bucket. The synchronization completes successfully, and the directory and bucket remain in a consistent state.  

   We are particularly interested in the file `test1.txt`. It is **6 B** size and was created at **13:00**. 
[test1.txt](https://github.com/user-attachments/files/19449835/test1.txt)

3. Some time passes, and a new build is triggered on machine `b2` from a new branch. The files are new and have an `mtime` of `14:00`. Some files are identical in terms of size and name, while others are different. However, all files are uploaded since they have a new `mtime`.  

   The file `test1.txt` is again **6 B** but has different content. It was uploaded because it was created after `13:00`. 
[test1.txt](https://github.com/user-attachments/files/19449844/test1.txt)

4. More time passes, and another build is triggered on `b1`, similar to the **step 2** one. Instead of generating files, we attempt to synchronize the cache.  

   The file `test1.txt` is identical to the one from **step 2**, but it will **not** be uploaded because its size is the same as the one uploaded in **step 3**. Additionally, its creation time is **13:00**, which is not greater than `13:00`. As a result, we end up in an inconsistent state and fail to upload an important file.

To avoid modifying our build workflow or introducing workarounds, I decided to improve `s5cmd` by adding **hash-based synchronization**. Files are now compared based on **size and hash**. If the hash or file size in `src` and `dst` are different, it will be updated. This simple rule solves our issue.

S3 supports **ETag**, which stores the **MD5 hash**. Computing the **MD5 checksum** for a local file is easy.

---

## What has been implemented?

1. **Added the `HashStrategy`**. The principle is simple:
   - If file sizes differ, the file is copied.
   - If sizes are the same but the hash (ETag/local MD5) differs, the file is copied.
   - If both size and MD5 checksum are the same, no upload occurs.

2. **Added the `--hash-only` flag**, which works only with the `sync` operation and enables the `HashStrategy`.

3. **Changed the mechanism for spawning goroutines** to check whether synchronization is needed. Previously, a single goroutine was used. That approach was acceptable but **degraded performance** with a large number of files.  
   - Now, I use the global `numworkers` parameter and create as many goroutines as this value.

4. **Stored the `ETag` value** when reading files from remote or local storage objects.

5. **Added tests** for hash-based synchronization.

---

## Important Considerations

1. I used the **`numWorkers`** parameter, but I’m unsure if this is the right approach.  
   - This parameter is global and, based on its description, is used for other operations.  
   - Additionally, it is used with the `parallel` object.  
   - Perhaps it would be better to introduce a **separate parameter** for `sync` (with the `--hash-only` flag) and modify the goroutine creation process to use `parallel`.

2. The **`HashStrategy`** relies not only on hash comparison but also on file size verification.  
   - This might be **misleading**, so renaming it to **`SizeAndHashStrategy`** might be more appropriate.

3. The hash could be computed **during the initial file read** (`fs.go`).  
   - However, this might **increase execution time** for other commands **without any practical benefit**.

4. I did not run **performance tests** using `bench.py`.  
   - I tested performance by building `s5cmd` from my fork and uploading files.
   - `bench.py` does not include tests for `sync`, and I don’t have the resources to test with a **large file (300GB)**.
   - If performance testing is **critical**, I can try modifying the benchmark and testing with a **limited file set (10GB)**.

5. I ran `make check` and **found no warnings or errors**.

6. **I am not a Go developer** and am unfamiliar with common **Go patterns and best practices**.  
   - I focused on **solving my problem** and then sharing my solution with others.  
   - I would appreciate it if someone with more **Go experience** and knowledge of `s5cmd` could review the implementation and highlight potential issues.
   