### PR TITLE
Fix segmentation violation when stat fails on source object for override determination

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -864,6 +864,11 @@ func (c Copy) shouldOverride(ctx context.Context, srcurl *url.URL, dsturl *url.U
 		return err
 	}
 
+	// if source not exists, cannot proceed with comparison
+	if srcObj == nil {
+		return fmt.Errorf("stat on source object returned nil")
+	}
+
 	dstClient, err := storage.NewClient(ctx, dsturl, c.storageOpts)
 	if err != nil {
 		return err


### PR DESCRIPTION
When using `--if-size-differ` or `--if-source-newer`, the source and destination objects have `stat` called on them to fetch metadata used for the override determination. Sometimes, this call can return an object not found error on the source object, despite us knowing the file exists. This can be either due to rate limiting, service disruptions, or the file being moved on the source before the stat can be called. When this happens, the code dereferences nil for the comparison since the object not found error was swallowed. I added a check to prevent this and raise an error about the unexpected stat failure.

---

**Segfault:**
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xa7684f]

goroutine 74887 [running]:
github.com/peak/s5cmd/v2/command.Copy.shouldOverride({0xc005ed4280, 0xc005ed4820, {0xbe9303, 0x2}, {0xc00511a2c0, 0xaa}, 0x0, 0x0, 0x1, 0x0, ...}, ...)
	/home/conda/feedstock_root/build_artifacts/bld/rattler-build_s5cmd_1737483372/work/command/cp.go:888 +0x18f
github.com/peak/s5cmd/v2/command.Copy.doDownload({0xc005ed4280, 0xc005ed4820, {0xbe9303, 0x2}, {0xc00511a2c0, 0xaa}, 0x0, 0x0, 0x1, 0x0, ...}, ...)
	/home/conda/feedstock_root/build_artifacts/bld/rattler-build_s5cmd_1737483372/work/command/cp.go:651 +0xf8
github.com/peak/s5cmd/v2/command.Copy.Run.Copy.prepareDownloadTask.func3()
	/home/conda/feedstock_root/build_artifacts/bld/rattler-build_s5cmd_1737483372/work/command/cp.go:605 +0xd4
github.com/peak/s5cmd/v2/parallel.(*Manager).Run.func1()
	/home/conda/feedstock_root/build_artifacts/bld/rattler-build_s5cmd_1737483372/work/parallel/parallel.go:57 +0x78
created by github.com/peak/s5cmd/v2/parallel.(*Manager).Run in goroutine 74949
	/home/conda/feedstock_root/build_artifacts/bld/rattler-build_s5cmd_1737483372/work/parallel/parallel.go:53 +0xb9
```

---

This should resolve issue #689