### PR TITLE
chore: Fix missing minio tag in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     services:
       minio:
-        image: ${{ (matrix.os == 'ubuntu') && 'bitnami/minio:2023.7.18' || ''}}
+        image: ${{ (matrix.os == 'ubuntu') && 'bitnamilegacy/minio:2023.7.18' || ''}}
         ports:
           - 45677:9000
         options: >-


### PR DESCRIPTION
The `minio` image was removed entirely from the `bitnami` repository and made available in `bitnamilegacy`. This is currently causing the CI to fail. Updated the workflow definition to pull the same image tag but from the correct repository.

**CI failures:**

```log
Error response from daemon: manifest for bitnami/minio:2023.7.18 not found: manifest unknown: manifest unknown
Warning: Docker pull failed with exit code 1, back off 7.984 seconds before retry.
/usr/bin/docker pull bitnami/minio:2023.7.18
Error response from daemon: manifest for bitnami/minio:2023.7.18 not found: manifest unknown: manifest unknown
Warning: Docker pull failed with exit code 1, back off 4.551 seconds before retry.
/usr/bin/docker pull bitnami/minio:2023.7.18
Error response from daemon: manifest for bitnami/minio:2023.7.18 not found: manifest unknown: manifest unknown
Error: Docker pull failed with exit code 1
```

**Message from bitnami:**
All existing container images have been migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.

https://hub.docker.com/r/bitnami/minio