### PR TITLE
docs: fix missing subcommand in cp example 22

### DIFF
--- a/command/cp.go
+++ b/command/cp.go
@@ -111,7 +111,7 @@ Examples:
 		 > s5cmd --request-payer=requester {{.HelpName}} s3://bucket/prefix/object.gz .
 
 	22. Upload a file to S3 with a content-type and content-encoding header
-		 > s5cmd --content-type "text/css" --content-encoding "br" myfile.css.br s3://bucket/
+		 > s5cmd {{.HelpName}} --content-type "text/css" --content-encoding "br" myfile.css.br s3://bucket/
 
 	23. Download the specific version of a remote object to working directory
 		 > s5cmd {{.HelpName}} --version-id VERSION_ID s3://bucket/prefix/object .


### PR DESCRIPTION
The example for uploading with content-type and content-encoding 
was missing the `cp` subcommand. This commit adds `cp` back 
to the example to ensure it is valid and copy-paste friendly.